### PR TITLE
fix: fixed path to sw.js

### DIFF
--- a/src/transformers/html.ts
+++ b/src/transformers/html.ts
@@ -14,7 +14,7 @@ export const HTMLTransformer = (options: VitePWAOptions): IndexHtmlTransform => 
 <script>
   if('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
-      navigator.serviceWorker.register('sw.js', { scope: './' })
+      navigator.serviceWorker.register('/sw.js', { scope: './' })
     })
   }
 </script>


### PR DESCRIPTION
If a page was loaded not from a root url (eg. `https://example.com/login`) script tries to load `sw.js` from current url like this – `https://example.com/login/sw.js`, not like this - `https://example.com/sw.js`.