### PR TITLE
fix: default workbox.mode to "production"

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "dev": "npm run build -- --watch",
-    "build": "tsup src/index.ts --dts --format cjs,esm",
+    "build": "tsup src/index.ts --env.NODE_ENV production --dts --format cjs,esm",
     "prepublishOnly": "npm run build",
     "release": "npx bumpp --push --tag --commit && npm publish",
     "example:dev": "npm -C example run dev",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "dev": "npm run build -- --watch",
-    "build": "tsup src/index.ts --env.NODE_ENV production --dts --format cjs,esm",
+    "build": "tsup src/index.ts --dts --format cjs,esm",
     "prepublishOnly": "npm run build",
     "release": "npx bumpp --push --tag --commit && npm publish",
     "example:dev": "npm -C example run dev",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export function VitePWA(options: Partial<VitePWAOptions> = {}): Plugin {
     swDest: `${outDir}/sw.js`,
     globDirectory: outDir,
     offlineGoogleAnalytics: false,
-    mode: process.env.NODE_ENV,
+    mode: process['env']['NODE_ENV'] || 'production',
   }
 
   const defaultManifest: Partial<ManifestOptions> = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export function VitePWA(options: Partial<VitePWAOptions> = {}): Plugin {
     swDest: `${outDir}/sw.js`,
     globDirectory: outDir,
     offlineGoogleAnalytics: false,
-    mode: process.env.NODE_ENV || 'development',
+    mode: process.env.NODE_ENV,
   }
 
   const defaultManifest: Partial<ManifestOptions> = {


### PR DESCRIPTION
`tsup` doesn't allow to include `process.env.NODE_ENV` piece (literally) in output. Instead, it writes value of it. This PR changes default of `workbox.mode` to `"production"`, because that's mostly desired, than `"development"`. 

`mode: "production"` results in minified output of service worker and workbox code.
Closes #8 