### PR TITLE
types(manifest): add missing scope and orientation

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,14 @@ export interface ManifestOptions {
    */
   start_url: string
   /**
+   * Restricts what web pages can be viewed while the manifest is applied
+   */
+  scope: string
+  /**
+   * Restricts what web pages can be viewed while the manifest is applied
+   */
+  orientation: 'any' | 'natural' | 'landscape' | 'landscape-primary' | 'landscape-secondary' | 'portrait' | 'portrait-primary' | 'portrait-secondary'
+  /**
    * Default: `standalone`
    */
   display: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export interface ManifestOptions {
    */
   scope: string
   /**
-   * Restricts what web pages can be viewed while the manifest is applied
+   * Defines the default orientation for all the website's top-level
    */
   orientation: 'any' | 'natural' | 'landscape' | 'landscape-primary' | 'landscape-secondary' | 'portrait' | 'portrait-primary' | 'portrait-secondary'
   /**


### PR DESCRIPTION
I found them missing but I directly edited the types files hoping it's enough 😬 