### PR TITLE
fix: ensure using `base` does not require additional configuration

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -3,23 +3,6 @@
 import { RuntimeCachingEntry } from 'workbox-build'
 
 export const cachePreset: RuntimeCachingEntry[] = [
-  // if you are customizing your runtime cache rules, please note that the
-  // first item in the runtime cache configuration array MUST be "start-url"
-  {
-    // MUST be the same as "start_url" in manifest.json
-    urlPattern: '/',
-    // use NetworkFirst or NetworkOnly if you redirect un-authenticated user to login page
-    // use StaleWhileRevalidate if you want to prompt user to reload when new version available
-    handler: 'NetworkFirst',
-    options: {
-      // don't change cache name
-      cacheName: 'start-url',
-      expiration: {
-        maxEntries: 1,
-        maxAgeSeconds: 24 * 60 * 60, // 24 hours
-      },
-    },
-  },
   {
     urlPattern: /^https:\/\/fonts\.(?:googleapis|gstatic)\.com\/.*/i,
     handler: 'CacheFirst',

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,7 +40,7 @@ export function resolveOptions(options: Partial<VitePWAOptions>, viteConfig: Res
     offlineGoogleAnalytics: false,
     runtimeCaching: cachePreset,
     mode,
-    navigateFallback: '/index.html',
+    navigateFallback: 'index.html',
   }
 
   const defaultInjectManifest: InjectManifestConfig = {
@@ -53,7 +53,7 @@ export function resolveOptions(options: Partial<VitePWAOptions>, viteConfig: Res
   const defaultManifest: Partial<ManifestOptions> = {
     name: pkg.name,
     short_name: pkg.name,
-    start_url: '/',
+    start_url: './', // Relative to the manifest URL, which already includes the base.
     display: 'standalone',
     background_color: '#ffffff',
     lang: 'en',


### PR DESCRIPTION
[relative]: https://developer.mozilla.org/en-US/docs/Web/Manifest/start_url#relative_url

### Description 📖 

This pull request makes a few changes to ensure that a Vite app using `base` doesn't require additional configuration in <kbd>vite-plugin-pwa</kbd>

### Changes ✏️ 

- Changed `start_url` to be [relative], so that when using `base` the `start_url` is resolved correctly.
- Removed a leading slash from the navigation fallback so that it matches the exact name that is rendered in the manifest, fixing an error when the service worker is first installed:
```
  WorkboxError.js:28 Uncaught (in promise) non-precached-url: non-precached-url :: [{"url":"/index.html"}]
```

### Notes 🗒️ 

Initially I thought about turning `cachePreset` into a function that receives `basePath`, and use:

```js
urlPattern: basePath,
```

but after investigating, it turns out that the first rule copied from <kbd>next-pwa</kbd> is not really used.

Since <kbd>vite-plugin-pwa</kbd> adds `index.html` to `navigateFallback`, the precaching rule will always match first, and that rule will never be used.
