### PR TITLE
fix: html link error url when use CDN.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: actions/checkout@v2
       - run: npx conventional-github-releaser -p angular
         env:
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{secrets.ACCESS_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> This is a modification package for debugging base on v0.5.2, please do not use. Please use the original package [vite-plugin-pwa](https://github.com/antfu/vite-plugin-pwa) .
+
 <p align='center'>
 <img src='https://repository-images.githubusercontent.com/290129345/d4bfc300-1866-11eb-8602-e672c9dd0e7d' alt="vite-plugin-pwa - Zero-config PWA for Vite">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "vite-plugin-pwa",
+  "name": "@chengpeiquan/vite-plugin-pwa",
   "description": "Zero-config PWA for Vite",
-  "version": "0.5.2",
+  "version": "0.1.1",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/src/html.ts
+++ b/src/html.ts
@@ -3,11 +3,10 @@ import { FILE_MANIFEST, FILE_SW_REGISTER } from './constants'
 import { ResolvedVitePWAOptions } from './types'
 
 function join(...args: string[]) {
-  const filePath: string = _join(...args).replace(/\\/g, '/');
-  if ( filePath.startsWith('/http') ) {
-    return filePath.slice(1);
+  if ( args[0] && args[0].startsWith('http') ) {
+    args[0] = '/';
   }
-  return filePath;
+  return _join(...args).replace(/\\/g, '/')
 }
 
 export function generateSWRegister(options: ResolvedVitePWAOptions) {

--- a/src/html.ts
+++ b/src/html.ts
@@ -3,7 +3,11 @@ import { FILE_MANIFEST, FILE_SW_REGISTER } from './constants'
 import { ResolvedVitePWAOptions } from './types'
 
 function join(...args: string[]) {
-  return _join(...args).replace(/\\/g, '/')
+  const filePath: string = _join(...args).replace(/\\/g, '/');
+  if ( filePath.startsWith('/http') ) {
+    return filePath.slice(1);
+  }
+  return filePath;
 }
 
 export function generateSWRegister(options: ResolvedVitePWAOptions) {


### PR DESCRIPTION
Hi, Anthony. When I set the config option [base](https://vitejs.dev/config/#base) as CDN like 'https://cdn.jsdelivr.net/gh/chengpeiquan/chengpeiquan.com@gh-pages/' in `vite.config.ts`, I found a problem:

Run build on my project, then, in `/dist` folder, all `html` files was added these codes:

```html
<link rel="manifest" href="/https:/cdn.jsdelivr.net/gh/chengpeiquan/chengpeiquan.com@gh-pages/manifest.webmanifest">

<script src="/https:/cdn.jsdelivr.net/gh/chengpeiquan/chengpeiquan.com@gh-pages/registerSW.js"></script>
```

They are start with `/https....`, so, in the browser they are 404.

I found the cause of the problem in [html.ts](https://github.com/antfu/vite-plugin-pwa/blob/master/src/html.ts#L5-L7)

Now, this PR already fixed it.