### PR TITLE
fix: add import script only when it's setted

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -25,12 +25,19 @@ export function injectServiceWorker(html: string, options: ResolvedVitePWAOption
 </head>`.trim(),
     )
   }
-  else {
+  else if(options.injectRegister === 'import') {
     return html.replace(
       '</head>',
       `
 <link rel="manifest" href="${join(options.base, FILE_MANIFEST)}">
 <script src="${join(options.base, FILE_SW_REGISTER)}"></script>
+</head>`.trim(),
+    )
+  } else {
+    return html.replace(
+      '</head>',
+      `
+<link rel="manifest" href="${join(options.base, FILE_MANIFEST)}">
 </head>`.trim(),
     )
   }


### PR DESCRIPTION
Enable user disable the insertion of import script registerSW when 'injectRegister' is set disticnt from 'inline' or 'import'.
This make the plugin be unopinated of registerSW import tag on index.html.