### PR TITLE
fix: auto inject register if virtual register isn't requested

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,6 @@ export function VitePWA(userOptions: Partial<VitePWAOptions> = {}): Plugin[] {
   return [
     {
       name: 'vite-plugin-pwa',
-      enforce: 'post',
       apply: 'build',
       configResolved(config) {
         viteConfig = config


### PR DESCRIPTION
The resolved plugins will be in the following order:

> * Alias
> * User plugins with enforce: 'pre'
> * Vite core plugins
> * User plugins without enforce value
> * Vite build plugins
> * User plugins with enforce: 'post'
> * Vite post build plugins (minify, manifest, reporting)

The `generateBundle` plugin will be executed before `transformIndexHtml`  if `vite-plugin-pwa` and `transformIndexHtml` set `enforce: 'post'` both. And `options.injectRegister` will be wrong.