### PR TITLE
docs: update test steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,16 +172,12 @@ If your TypeScript build step or IDE complain about not being able to find modul
 ### Testing service worker
 
 Since this plugin will not generate the service worker on `development`, you can test it on local following these steps:
-1) install `https-localhost` as a `dev` dependency: `npm i --save-dev https-localhost`
-2) add `https-preview` script to your `package.json`:
-```json
-"https-preview": "serve dist"
-```
-3) build your app and run `https-preview`: `npm run build && npm run https-preview`.
 
-First time you run it, it will ask you about installing a certificate (that will be generated for you),
-confirm installation on OS (keychain on macosx and certificate manager on windows) and open `https://localhost` 
-on browser.
+1) add `serve` script to your `package.json` if not before:
+```json
+"serve": "vite preview"
+```
+2) build your app and run `serve`: `npm run build && npm run serve`.
 
 ## Sponsors
 


### PR DESCRIPTION
> [In order to facilitate local development, localhost is considered a secure origin by browsers as well. ](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers#setting_up_to_play_with_service_workers)

So `vite preview` worked well.