### PR TITLE
chore: add more options to ManifestOptions

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -96,13 +96,6 @@ export function resolveOptions(options: Partial<VitePWAOptions>, viteConfig: Res
     background_color: '#ffffff',
     lang: 'en',
     scope,
-    related_applications: [],
-    prefer_related_applications: false,
-    protocol_handlers: [],
-    shortcuts: [],
-    screenshots: [],
-    categories: [],
-    iarc_rating_id,    
   }
 
   const workbox = Object.assign({}, defaultWorkbox, options.workbox || {})

--- a/src/options.ts
+++ b/src/options.ts
@@ -96,6 +96,13 @@ export function resolveOptions(options: Partial<VitePWAOptions>, viteConfig: Res
     background_color: '#ffffff',
     lang: 'en',
     scope,
+    related_applications: [],
+    prefer_related_applications: false,
+    protocol_handlers: [],
+    shortcuts: [],
+    screenshots: [],
+    categories: [],
+    iarc_rating_id,    
   }
 
   const workbox = Object.assign({}, defaultWorkbox, options.workbox || {})

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,4 +147,52 @@ export interface ManifestOptions {
    * @default A combination of `routerBase` and `options.build.publicPath`
    */
   publicPath: string
+  /**
+   * @default []
+   */
+  related_applications: {
+    platform: string,
+    url: string,
+    id?: string,
+  }[]
+  /**
+   * @default false
+   */
+  prefer_related_applications: boolean
+  /**
+   * @default []
+   */
+  protocol_handlers: {
+    protocol: string,
+    url: string,
+  }[]
+  /**
+   * @default []
+   */
+  shortcuts: {
+    name: string,
+    short_name?: string,
+    url: string,
+    description?: string,
+    icons: []string,
+  }[]
+  /**
+   * @default []
+   */
+  screenshots: {
+    src: string,
+    sizes: string,
+    label?: string,
+    platform?: 'narrow' | 'wide' | 'android' | 'ios' | 'kaios' | 'macos' | 'windows' | 'windows10x' | 'chrome_web_store' | 'play' | 'itunes' | 'microsoft-inbox' | 'microsoft-store' | string
+    type?: string,
+  }[]
+  /**
+   * @default []
+   */
+  categories: []string
+    /**
+   * @default ''
+   */
+  iarc_rating_id: string
+  [key: string]: any,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -194,5 +194,4 @@ export interface ManifestOptions {
    * @default ''
    */
   iarc_rating_id: string
-  [key: string]: any
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,7 +190,7 @@ export interface ManifestOptions {
    * @default []
    */
   categories: []string
-    /**
+  /**
    * @default ''
    */
   iarc_rating_id: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -194,5 +194,5 @@ export interface ManifestOptions {
    * @default ''
    */
   iarc_rating_id: string
-  [key: string]: any,
+  [key: string]: any
 }


### PR DESCRIPTION
Added some more missing types for ManifestOptions and and a catch-all at the end in case some new ones are added that this library don't document