### PR TITLE
test: add web worker to test vite web worker plugin

### DIFF
--- a/examples/vue-basic-inject-manifest/src/App.vue
+++ b/examples/vue-basic-inject-manifest/src/App.vue
@@ -1,15 +1,51 @@
 <script setup lang="ts">
+import { ref, onBeforeMount } from 'vue'
 import { useTimeAgo } from '@vueuse/core'
+import Worker from './my-worker?worker'
+
 import ReloadPrompt from './ReloadPrompt.vue'
+
+const pong = ref(null)
+const mode = ref(null)
+const worker = new Worker()
 
 // replaced dyanmicaly
 const date = '__DATE__'
 const timeAgo = useTimeAgo(date)
+
+const runWorker = async() => {
+  worker.postMessage('ping')
+}
+const resetMessage = async() => {
+  worker.postMessage('clear')
+}
+const messageFromWorker = async({ data: { msg, mode: useMode } }) => {
+  pong.value = msg
+  mode.value = useMode
+}
+
+onBeforeMount(() => {
+  worker.addEventListener('message', messageFromWorker)
+})
 </script>
 
 <template>
   <img src="/favicon.svg" width="60" height="60">
   <br>
   <div>Built at: {{ date }} ({{ timeAgo }})</div>
+  <br />
+  <br />
+  <button @click="runWorker">
+    Ping web worker
+  </button>
+  &#160;&#160;
+  <button @click="resetMessage">
+    Reset message
+  </button>
+  <br />
+  <br />
+  <template v-if="pong">
+    Response from web worker: <span> Message: {{ pong }} </span>&#160;&#160;<span> Using ENV mode: {{ mode }}</span>
+  </template>
   <ReloadPrompt />
 </template>

--- a/examples/vue-basic-inject-manifest/src/my-worker.js
+++ b/examples/vue-basic-inject-manifest/src/my-worker.js
@@ -1,0 +1,13 @@
+import { msg, mode } from './workerImport'
+
+let counter = 1
+
+self.onmessage = (e) => {
+  if (e.data === 'ping') {
+    self.postMessage({ msg: `${msg} - ${counter++}`, mode })
+  }
+  else if (e.data === 'clear') {
+    counter = 1
+    self.postMessage({ msg: null, mode: null })
+  }
+}

--- a/examples/vue-basic-inject-manifest/src/workerImport.js
+++ b/examples/vue-basic-inject-manifest/src/workerImport.js
@@ -1,0 +1,2 @@
+export const msg = 'pong'
+export const mode = process.env.NODE_ENV

--- a/examples/vue-router/src/App.vue
+++ b/examples/vue-router/src/App.vue
@@ -1,10 +1,32 @@
 <script setup lang="ts">
+import { ref, onBeforeMount } from 'vue'
 import { useTimeAgo } from '@vueuse/core'
+import MyWorker from './my-worker?worker'
+
 import ReloadPrompt from './ReloadPrompt.vue'
+
+const pong = ref(null)
+const mode = ref(null)
+const worker = new MyWorker()
 
 // replaced dyanmicaly
 const date = '__DATE__'
 const timeAgo = useTimeAgo(date)
+
+const runWorker = async() => {
+  worker.postMessage('ping')
+}
+const resetMessage = async() => {
+  worker.postMessage('clear')
+}
+const messageFromWorker = async({ data: { msg, mode: useMode } }) => {
+  pong.value = msg
+  mode.value = useMode
+}
+
+onBeforeMount(() => {
+  worker.addEventListener('message', messageFromWorker)
+})
 </script>
 
 <template>
@@ -13,5 +35,19 @@ const timeAgo = useTimeAgo(date)
   <div>Built at: {{ date }} ({{ timeAgo }})</div>
   <br>
   <router-view />
+  <br />
+  <br />
+  <button @click="runWorker">
+    Ping web worker
+  </button>
+  &#160;&#160;
+  <button @click="resetMessage">
+    Reset message
+  </button>
+  <br />
+  <br />
+  <template v-if="pong">
+    Response from web worker: <span> Message: {{ pong }} </span>&#160;&#160;<span> Using ENV mode: {{ mode }}</span>
+  </template>
   <ReloadPrompt />
 </template>

--- a/examples/vue-router/src/my-worker.js
+++ b/examples/vue-router/src/my-worker.js
@@ -1,0 +1,13 @@
+import { msg, mode } from './workerImport'
+
+let counter = 1
+
+self.onmessage = (e) => {
+  if (e.data === 'ping') {
+    self.postMessage({ msg: `${msg} - ${counter++}`, mode })
+  }
+  else if (e.data === 'clear') {
+    counter = 1
+    self.postMessage({ msg: null, mode: null })
+  }
+}

--- a/examples/vue-router/src/workerImport.js
+++ b/examples/vue-router/src/workerImport.js
@@ -1,0 +1,2 @@
+export const msg = 'pong'
+export const mode = process.env.NODE_ENV


### PR DESCRIPTION
This PR includes a `web worker` similar to [vite worker playground](https://github.com/vitejs/vite/tree/main/packages/playground/worker). See [vite web workers](https://vitejs.dev/guide/features.html#web-workers).

We need to check that the builds will not fail when using `generateWS` or `injectManifest`, so I include the `web worker` on `vue-router` and `vue-basic-inject-manifest` examples.