### PR TITLE
feat: add service worker registration callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,32 @@ VitePWA({
 })
 ```
 
+### Configure application to check for Service Worker updates
+
+As explained in `Manual Updates` entry on `The Service Worker Lifecycle` [here](https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#manual_updates),
+you can use this code to configure this behavior on your application:
+
+```ts
+// main.ts
+import { registerSW } from 'virtual:pwa-register'
+
+const updateSW = registerSW({
+  // other options
+  onRegisted(r) {
+    r && setInterval(() => {
+      r.update()
+    }, 60 * 60 * 1000 /* 1 hour: timeout in milliseconds */)
+  }
+})
+```
+
+**Warning**: since `workbox-window` uses a time-based `heuristic` algorithm to handle service worker updates, if you 
+build your service worker and register it again, if the time between last registration and the new one is less than 
+1 minute, then, `workbox-window` will handle the `service worker update found` event as an external event, and so the
+behavior could be strange (for example, if using `prompt`, instead showing the dialog for new content available, the 
+ready  to work offline dialog will be shown; if using `autoUpdate`, the ready to work offline dialog will be shown and 
+shouldn't be shown).
+
 ### Full config
 
 Check out the type declaration [src/types.ts](./src/types.ts) and the following links for more details.

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ import { registerSW } from 'virtual:pwa-register'
 
 const updateSW = registerSW({
   // other options
-  onRegisted(r) {
+  onRegistered(r) {
     r && setInterval(() => {
       r.update()
     }, 60 * 60 * 1000 /* 1 hour: timeout in milliseconds */)

--- a/client.d.ts
+++ b/client.d.ts
@@ -3,6 +3,8 @@ declare module 'virtual:pwa-register' {
     immediate?: boolean
     onNeedRefresh?: () => void
     onOfflineReady?: () => void
+    onRegistered?: (registration: ServiceWorkerRegistration | undefined) => void
+    onRegisterError?: (error: any) => void
   }
 
   export function registerSW(options?: RegisterSWOptions): (reloadPage?: boolean) => Promise<void>
@@ -16,6 +18,8 @@ declare module 'virtual:pwa-register/vue' {
     immediate?: boolean
     onNeedRefresh?: () => void
     onOfflineReady?: () => void
+    onRegistered?: (registration: ServiceWorkerRegistration | undefined) => void
+    onRegisterError?: (error: any) => void
   }
 
   export function useRegisterSW(options?: RegisterSWOptions): {

--- a/examples/vue-router/package.json
+++ b/examples/vue-router/package.json
@@ -4,11 +4,15 @@
   "private": true,
   "scripts": {
     "start": "npm run run-build && npm run serve",
+    "start-reloadsw": "npm run run-build-reloadsw && npm run serve",
     "start-claims": "npm run run-build-claims && npm run serve",
+    "start-claims-reloadsw": "npm run run-build-reloadsw-claims && npm run serve",
     "dev": "cross-env DEBUG=vite-plugin-pwa:* vite",
     "build": "cross-env DEBUG=vite-plugin-pwa:* vite build",
     "run-build": "cross-env DEBUG=vite-plugin-pwa:* BASE_URL=/ SOURCE_MAP=true vite build",
+    "run-build-reloadsw": "cross-env DEBUG=vite-plugin-pwa:* BASE_URL=/ SOURCE_MAP=true RELOAD_SW=true vite build",
     "run-build-claims": "cross-env DEBUG=vite-plugin-pwa:* BASE_URL=/ SOURCE_MAP=true CLAIMS=true vite build",
+    "run-build-reloadsw-claims": "cross-env DEBUG=vite-plugin-pwa:* BASE_URL=/ SOURCE_MAP=true CLAIMS=true RELOAD_SW=true vite build",
     "serve": "serve dist"
   },
   "dependencies": {

--- a/examples/vue-router/src/ReloadPrompt.vue
+++ b/examples/vue-router/src/ReloadPrompt.vue
@@ -6,7 +6,11 @@ const {
   offlineReady,
   needRefresh,
   updateServiceWorker,
-} = useRegisterSW()
+} = useRegisterSW({
+  onRegistered(r) {
+    console.log(`SW Registered: ${r}`)
+  },
+})
 
 const close = async() => {
   offlineReady.value = false

--- a/examples/vue-router/src/ReloadPrompt.vue
+++ b/examples/vue-router/src/ReloadPrompt.vue
@@ -2,13 +2,24 @@
 <script setup lang="ts">
 import { useRegisterSW } from 'virtual:pwa-register/vue'
 
+// replaced dyanmicaly
+const reloadSW: any = '__RELOAD_SW__'
+
 const {
   offlineReady,
   needRefresh,
   updateServiceWorker,
 } = useRegisterSW({
   onRegistered(r) {
-    console.log(`SW Registered: ${r}`)
+    if (reloadSW === 'true') {
+      r && setInterval(async() => {
+        console.log('Checking for sw update')
+        await r.update()
+      }, 20000 /* 20s for testing purposes */)
+    }
+    else {
+      console.log(`SW Registered: ${r}`)
+    }
   },
 })
 
@@ -16,6 +27,7 @@ const close = async() => {
   offlineReady.value = false
   needRefresh.value = false
 }
+
 </script>
 
 <template>

--- a/examples/vue-router/vite.config.ts
+++ b/examples/vue-router/vite.config.ts
@@ -41,6 +41,7 @@ const config: UserConfig = {
     }),
     replace({
       __DATE__: new Date().toISOString(),
+      __RELOAD_SW__: process.env.RELOAD_SW === 'true' ? 'true' : 'false',
     }),
   ],
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "example:router:dev": "npm -C examples/vue-router run dev",
     "example:router:build": "npm -C examples/vue-router run build",
     "example:router:start": "npm -C examples/vue-router run start",
+    "example:router:start:reloadsw": "npm -C examples/vue-router run start-reloadsw",
     "example:router:start:claims": "npm -C examples/vue-router run start-claims",
+    "example:router:start:claims:reloadsw": "npm -C examples/vue-router run start-claims-reloadsw",
     "example:dev:cdn": "npm -C examples/vue-basic-cdn run dev",
     "example:build:cdn": "npm -C examples/vue-basic-cdn run build",
     "example:start:cdn": "npm -C examples/vue-basic-cdn run start"

--- a/src/client/build/register.ts
+++ b/src/client/build/register.ts
@@ -14,6 +14,8 @@ export function registerSW(options: RegisterSWOptions = {}) {
     immediate = false,
     onNeedRefresh,
     onOfflineReady,
+    onRegistered,
+    onRegisterError,
   } = options
 
   let wb: Workbox | undefined
@@ -76,7 +78,12 @@ export function registerSW(options: RegisterSWOptions = {}) {
     }
 
     // register the service worker
-    wb.register({ immediate }).then(r => registration = r)
+    wb.register({ immediate }).then((r) => {
+      registration = r
+      onRegistered?.(r)
+    }).catch((e) => {
+      onRegisterError?.(e)
+    })
   }
 
   return updateServiceWorker

--- a/src/client/build/vue.ts
+++ b/src/client/build/vue.ts
@@ -9,6 +9,8 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
     immediate = true,
     onNeedRefresh,
     onOfflineReady,
+    onRegistered,
+    onRegisterError,
   } = options
 
   const needRefresh = ref(false)
@@ -24,6 +26,8 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
       offlineReady.value = true
       onOfflineReady?.()
     },
+    onRegistered,
+    onRegisterError,
   })
 
   return {

--- a/src/client/type.d.ts
+++ b/src/client/type.d.ts
@@ -2,4 +2,6 @@ export type RegisterSWOptions = {
   immediate?: boolean
   onNeedRefresh?: () => void
   onOfflineReady?: () => void
+  onRegistered?: (registration: ServiceWorkerRegistration | undefined) => void
+  onRegisterError?: (error: any) => void
 }


### PR DESCRIPTION
This PR includes:
- add sw register callback
- add sw register error callback
- ~~add an example for logging to console the registration on router example (`ReloadPromp.vue`)~~
- add a working example on `vue-router` (configurable on `ReloadPrompt.vue` via `@rollup/plugin-replace`)

closes #93 
