### PR TITLE
docs: fix large code blocks and finish workbox entry

### DIFF
--- a/docs/.vitepress/theme/styles/layout.css
+++ b/docs/.vitepress/theme/styles/layout.css
@@ -293,3 +293,10 @@ html.dark .prompt-img img {
   filter: invert(93%);
 }
 
+details summary {
+  cursor: pointer;
+}
+details summary strong {
+  color: var(--c-brand-active);
+}
+

--- a/docs/frameworks/vue.md
+++ b/docs/frameworks/vue.md
@@ -7,6 +7,9 @@ You can use the built-in `Vite` virtual module `virtual:pwa-register/vue` for `V
 
 You can use this `ReloadPrompt.vue` component:
 
+<details>
+  <summary><strong>ReloadPrompt.vue</strong> code</summary>
+
 ```vue
 <script setup lang="ts">
 import { useRegisterSW } from 'virtual:pwa-register/vue'
@@ -71,6 +74,7 @@ const close = async() => {
 }
 </style>
 ```
+</details>
 
 ### Periodic SW Updates
 
@@ -120,6 +124,9 @@ and then inside `onRegisterError`, just notify the user that there was an error 
 Since this plugin only supports `Vuejs 3`, you cannot use the virtual module `virtual:pwa-register/vue`.
 
 You can copy `useRegisterSW.js` `mixin` to your `@/mixins/` directory in your application to make it working:
+
+<details>
+  <summary><strong>useRegisterSW.js</strong> code</summary>
 
 ```js
 export default {
@@ -176,8 +183,12 @@ export default {
   }
 }
 ```
+</details>
 
 You can use this `ReloadPrompt.vue` component:
+
+<details>
+  <summary><strong>ReloadPrompt.vue</strong> code</summary>
 
 ```vue
 <script>
@@ -237,6 +248,7 @@ export default {
 }
 </style>
 ```
+</details>
 
 ### Periodic SW Updates
 

--- a/docs/guide/generate.md
+++ b/docs/guide/generate.md
@@ -2,7 +2,7 @@
 
 Edit your `vite.config.ts` file to add `Vite Plugin PWA Plugin`:
 
-<details open>
+<details>
   <summary><strong>VitePWA options</strong> code</summary>
 
 ```ts
@@ -68,7 +68,7 @@ Once generated, download the ZIP and use
 You will also need to change your `index.html` file to include at least the following content to meet PWA requirements,
 you must change the `title` and the `description`, `favicon.svg` is the svg you have created:
 
-<details open>
+<details>
   <summary><strong>index.html</strong> code</summary>
 
 ```html

--- a/docs/guide/generate.md
+++ b/docs/guide/generate.md
@@ -2,6 +2,9 @@
 
 Edit your `vite.config.ts` file to add `Vite Plugin PWA Plugin`:
 
+<details open>
+  <summary><strong>VitePWA options</strong> code</summary>
+
 ```ts
 import { VitePWA } from 'vite-plugin-pwa'
 export const defineConfig({
@@ -36,6 +39,7 @@ export const defineConfig({
   ]    
 })
 ```
+</details>
 
 You will need to create your `robots.txt`, `favicon.svg` and/or `favicon.ico`, `apple-touch-icon.png`.
 
@@ -64,6 +68,9 @@ Once generated, download the ZIP and use
 You will also need to change your `index.html` file to include at least the following content to meet PWA requirements,
 you must change the `title` and the `description`, `favicon.svg` is the svg you have created:
 
+<details open>
+  <summary><strong>index.html</strong> code</summary>
+
 ```html
 <head>
   <meta charset="utf-8">
@@ -77,6 +84,7 @@ you must change the `title` and the `description`, `favicon.svg` is the svg you 
   <meta name="theme-color" content="#ffffff">
 </head>
 ```
+</details>
 
 The `theme-color` in the html and the` theme_color` in the PWA `manifest` entry should match, change it to the color 
 you want. 

--- a/docs/guide/periodic-sw-updates.md
+++ b/docs/guide/periodic-sw-updates.md
@@ -4,7 +4,7 @@ As explained in [Manual Updates](https://developers.google.com/web/fundamentals/
 entry on `The Service Worker Lifecycle`, you can use this code to configure periodic service worker updates on your 
 application on your `main.ts` or `main.js`:
 
-<details open>
+<details>
   <summary><strong>main.ts / main.js</strong> code</summary>
 
 ```ts

--- a/docs/guide/periodic-sw-updates.md
+++ b/docs/guide/periodic-sw-updates.md
@@ -4,6 +4,9 @@ As explained in [Manual Updates](https://developers.google.com/web/fundamentals/
 entry on `The Service Worker Lifecycle`, you can use this code to configure periodic service worker updates on your 
 application on your `main.ts` or `main.js`:
 
+<details open>
+  <summary><strong>main.ts / main.js</strong> code</summary>
+
 ```ts
 import { registerSW } from 'virtual:pwa-register'
 
@@ -17,6 +20,7 @@ const updateSW = registerSW({
   }
 })
 ```
+</details>
 
 The interval must be in milliseconds, in the example above it is configured to check the service worker every hour.
 

--- a/docs/workbox/generate-ws.md
+++ b/docs/workbox/generate-ws.md
@@ -20,7 +20,7 @@ On `index.html` file you must configure the `css` `link`, you **MUST** also incl
 for the external resources 
 (see [Handle Third Party Requests](https://developers.google.com/web/tools/workbox/guides/handle-third-party-requests) <outbound-link />):
 
-<details open>
+<details>
   <summary><strong>index.html</strong> code</summary>
 
 ```html
@@ -36,7 +36,7 @@ for the external resources
 
 Then on your `vite.config.ts` file add the following code:
 
-<details open>
+<details>
   <summary><strong>VitePWA options</strong> code</summary>
 
 ```ts
@@ -83,7 +83,7 @@ You can add this code to the plugin on your `vite.config.ts` file to add a `Back
 
 > You also need to add the logic to interact from the client logic: [Generate Service Worker](/guide/generate.html).
 
-<details open>
+<details>
   <summary><strong>VitePWA options</strong> code</summary>
 
 ```ts

--- a/docs/workbox/generate-ws.md
+++ b/docs/workbox/generate-ws.md
@@ -3,18 +3,25 @@
 You must read [Which Mode to Use](https://developers.google.com/web/tools/workbox/modules/workbox-build#which_mode_to_use) <outbound-link />
 before decide using this strategy on `vite-plugin-pwa` plugin.
 
-You can find the documentation for this method on `workbox` site: [generateWS](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.generateSW) <outbound-link />
+You can find the documentation for this method on `workbox` site: [generateWS](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.generateSW) <outbound-link />.
 
-## Cache external resources
+You can find a guide for plugins on `workbox` site: [Using Plugins](https://developers.google.com/web/tools/workbox/guides/using-plugins) <outbound-link />.
 
-If you use some `CDN` to download some resources like `fonts` and `css` you must include them into the service worker
-precache, and so your application can work when offline.
+## Cache External Resources
+
+If you use some `CDN` to download some resources like `fonts` and `css`, you must include them into the service worker
+precache, and so your application will work when offline.
 
 > You also need to add the logic to interact from the client logic: [Generate Service Worker](/guide/generate.html).
 
-The following example will use `css` from `https://fonts.gstatic.com` and `fonts` from `https://fonts.googleapis.com`.
+The following example will use `css` from `https://fonts.googleapis.com` and `fonts` from `https://fonts.gstatic.com`.
 
-On `index.html` file we must configure the `css`, you **MUST** include `crossorigin="anonymous"` for the external resources:
+On `index.html` file you must configure the `css` `link`, you **MUST** also include `crossorigin="anonymous"` attribute
+for the external resources 
+(see [Handle Third Party Requests](https://developers.google.com/web/tools/workbox/guides/handle-third-party-requests) <outbound-link />):
+
+<details open>
+  <summary><strong>index.html</strong> code</summary>
 
 ```html
 <head>
@@ -25,8 +32,12 @@ On `index.html` file we must configure the `css`, you **MUST** include `crossori
   <link rel="stylesheet" crossorigin="anonymous" href="https://fonts.googleapis.com/css2?family=Fira+Code&display=swap" />
 </head>
 ```
+</details>
 
 Then on your `vite.config.ts` file add the following code:
+
+<details open>
+  <summary><strong>VitePWA options</strong> code</summary>
 
 ```ts
 VitePWA({
@@ -64,12 +75,16 @@ VitePWA({
   }
 })  
 ```
+</details>
 
 ## Background Sync
 
-You can add this code to the plugin on your `vite.config.ts` to add a `Background Sync` manager to your service worker:
+You can add this code to the plugin on your `vite.config.ts` file to add a `Background Sync` manager to your service worker:
 
 > You also need to add the logic to interact from the client logic: [Generate Service Worker](/guide/generate.html).
+
+<details open>
+  <summary><strong>VitePWA options</strong> code</summary>
 
 ```ts
 VitePWA({
@@ -90,3 +105,4 @@ VitePWA({
   }
 })
 ```
+</details>

--- a/docs/workbox/index.md
+++ b/docs/workbox/index.md
@@ -11,7 +11,8 @@ module from **Workbox**.
 
 ### workbox-build module
 
-This module is for build process purpose (is is a `node` module), that is, `Vite Plugin PWA` will use it to build your service.
+This module is for build process purpose (it is a `node` module), that is, `Vite Plugin PWA` will use it to build your 
+service worker.
 
 We focus on 2 methods of this module:
 - [generateWS](/workbox/generate-ws): for generating the service worker.
@@ -31,10 +32,10 @@ the code for you).
 `vite-plugin-pwa` will use internally `generateWS` and `injectManifest` `workbox` methods when `strategies` 
 option is `generateWS` and `injectManifest` respectively.
 
-When you configure `strategies: 'generateWS'` (it is the default value) option on your `vite.config.ts`, then the 
-plugin invoke  the workbox `generateWS` method: the options passed to the `workbox` method will be the provided on 
+When you configure `strategies: 'generateWS'` option (it is the default value) on your `vite.config.ts` file, then the 
+plugin invoke the workbox `generateWS` method: the options passed to the `workbox` method will be the provided on 
 the plugin configuration.
 
-When you configure `strategies: 'injectManifest'` plugin option on your `vite.config.ts`, then the plugin will first 
+When you configure `strategies: 'injectManifest'` plugin option on your `vite.config.ts` file, the plugin will first 
 build your custom service worker via `rollup` and then, with previous build result will call to workbox `injectManifest` 
 method: the options passed to the `workbox` method will be the provided on the plugin configuration.

--- a/docs/workbox/inject-manifest.md
+++ b/docs/workbox/inject-manifest.md
@@ -13,7 +13,7 @@ You can find the documentation for this method on `workbox` site: [injectManifes
 You can use the following code to create your custom service worker to be used with network first strategy. We also include
 how to configure [Custom Cache Network Race Strategy](https://jakearchibald.com/2014/offline-cookbook/#cache--network-race) <outbound-link />.
 
-<details open>
+<details>
   <summary><strong>VitePWA options</strong> code</summary>
 
 ```ts
@@ -32,7 +32,7 @@ dependencies:
 - `workbox-strategies`
 - `workbox-build`
 
-<details open>
+<details>
   <summary><strong>src/sw.ts</strong> code</summary>
 
 ```ts
@@ -176,7 +176,7 @@ You can use this code on your custom service worker (`src/sw.ts`) to enable `Ser
 
 > You also need to add the logic to interact from the client logic: [Advanced (injectManifest)](/guide/inject-manifest.html).
 
-<details open>
+<details>
   <summary><strong>src/sw.ts</strong> code</summary>
 
 ```ts

--- a/docs/workbox/inject-manifest.md
+++ b/docs/workbox/inject-manifest.md
@@ -8,11 +8,176 @@ looking for some plugin on `workbox` site on [Runtime Caching Entry](https://dev
 
 You can find the documentation for this method on `workbox` site: [injectManifest](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.injectManifest) <outbound-link />
 
-## Server push notifications
+## Network First Service Worker
+
+You can use the following code to create your custom service worker to be used with network first strategy. We also include
+how to configure [Custom Cache Network Race Strategy](https://jakearchibald.com/2014/offline-cookbook/#cache--network-race) <outbound-link />.
+
+<details open>
+  <summary><strong>VitePWA options</strong> code</summary>
+
+```ts
+VitePWA({
+  strategies: 'injectManifest',
+  srcDir: 'src',
+  filename: 'sw.ts'
+})
+```
+</details>
+
+then in your `src/sw.ts` file, remember you will also need to add following `workbox` dependencies as `dev`
+dependencies:
+- `workbox-core`
+- `workbox-routing`
+- `workbox-strategies`
+- `workbox-build`
+
+<details open>
+  <summary><strong>src/sw.ts</strong> code</summary>
+
+```ts
+/* eslint-disable no-console */
+import { clientsClaim, cacheNames } from 'workbox-core'
+import { registerRoute, setCatchHandler, setDefaultHandler } from 'workbox-routing'
+import {
+  NetworkFirst,
+  NetworkOnly,
+  Strategy,
+  StrategyHandler,
+} from 'workbox-strategies'
+import { ManifestEntry } from 'workbox-build'
+
+// Give TypeScript the correct global.
+// @ts-ignore
+declare let self: ServiceWorkerGlobalScope
+declare type ExtendableEvent = any
+
+const data = {
+  race: true,
+  debug: false,
+  credentials: 'same-origin',
+  networkTimeoutSeconds: 0,
+  fallback: 'index.html'
+}
+
+const cacheName = cacheNames.runtime
+
+const buildStrategy = (): Strategy => {
+  if (race) {
+    class CacheNetworkRace extends Strategy {
+      _handle(request: Request, handler: StrategyHandler): Promise<Response | undefined> {
+        const fetchAndCachePutDone: Promise<Response> = handler.fetchAndCachePut(request)
+        const cacheMatchDone: Promise<Response | undefined> = handler.cacheMatch(request)
+
+        return new Promise((resolve, reject) => {
+          fetchAndCachePutDone.then(resolve).catch((e) => {
+            if (debug)
+              console.log(`Cannot fetch resource: ${request.url}`, e)
+          })
+          cacheMatchDone.then(response => response && resolve(response))
+
+          // Reject if both network and cache error or find no response.
+          Promise.allSettled([fetchAndCachePutDone, cacheMatchDone]).then((results) => {
+            const [fetchAndCachePutResult, cacheMatchResult] = results
+            // @ts-ignore
+            if (fetchAndCachePutResult.status === 'rejected' && !cacheMatchResult.value)
+              reject(fetchAndCachePutResult.reason)
+          })
+        })
+      }
+    }
+    return new CacheNetworkRace()
+  }
+  else {
+    if (networkTimeoutSeconds > 0)
+      return new NetworkFirst({ cacheName, networkTimeoutSeconds })
+    else
+      return new NetworkFirst({ cacheName })
+  }
+}
+
+const manifest = self.__WB_MANIFEST as Array<ManifestEntry>
+
+const cacheEntries: RequestInfo[] = []
+
+const manifestURLs = manifest.map(
+  (entry) => {
+    // @ts-ignore
+    const url = new URL(entry.url, self.location)
+    cacheEntries.push(new Request(url.href, {
+      credentials: credentials as any
+    }))
+    return url.href
+  }
+)
+
+self.addEventListener('install', (event: ExtendableEvent) => {
+  event.waitUntil(
+    caches.open(cacheName).then((cache) => {
+      return cache.addAll(cacheEntries)
+    })
+  )
+})
+
+self.addEventListener('activate', (event: ExtendableEvent) => {
+  // - clean up outdated runtime cache
+  event.waitUntil(
+    caches.open(cacheName).then((cache) => {
+      // clean up those who are not listed in manifestURLs
+      cache.keys().then((keys) => {
+        keys.forEach((request) => {
+          debug && console.log(`Checking cache entry to be removed: ${request.url}`)
+          if (!manifestURLs.includes(request.url)) {
+            cache.delete(request).then((deleted) => {
+              if (debug) {
+                if (deleted)
+                  console.log(`Precached data removed: ${request.url || request}`)
+                else
+                  console.log(`No precache found: ${request.url || request}`)
+              }
+            })
+          }
+        })
+      })
+    })
+  )
+})
+
+registerRoute(
+  ({ url }) => manifestURLs.includes(url.href),
+  buildStrategy()
+)
+
+setDefaultHandler(new NetworkOnly())
+
+// fallback to app-shell for document request
+setCatchHandler(({ event }): Promise<Response> => {
+  // @ts-ignore
+  switch (event.request.destination) {
+    case 'document':
+      return caches.match(fallback).then((r) => {
+        return r ? Promise.resolve(r) : Promise.resolve(Response.error())
+      })
+    default:
+      return Promise.resolve(Response.error())
+  }
+})
+
+// this is necessary, since the new service worker will keep on skipWaiting state
+// and then, caches will not be cleared since it is not activated
+self.skipWaiting()
+clientsClaim()
+```
+</details>
+
+## Server Push Notifications
 
 You can use this code on your custom service worker (`src/sw.ts`) to enable `Server Push Notifications`:
 
 > You also need to add the logic to interact from the client logic: [Advanced (injectManifest)](/guide/inject-manifest.html).
+
+<details open>
+  <summary><strong>src/sw.ts</strong> code</summary>
 
 ```ts
 function getEndpoint() {
@@ -48,3 +213,4 @@ self.addEventListener('push', function(event) {
   );
 })
 ```
+</details>

--- a/docs/workbox/inject-manifest.md
+++ b/docs/workbox/inject-manifest.md
@@ -8,7 +8,7 @@ looking for some plugin on `workbox` site on [Runtime Caching Entry](https://dev
 
 You can find the documentation for this method on `workbox` site: [injectManifest](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.injectManifest) <outbound-link />
 
-## Network First Service Worker
+## Network First Strategy
 
 You can use the following code to create your custom service worker to be used with network first strategy. We also include
 how to configure [Custom Cache Network Race Strategy](https://jakearchibald.com/2014/offline-cookbook/#cache--network-race) <outbound-link />.
@@ -25,7 +25,9 @@ VitePWA({
 ```
 </details>
 
-then in your `src/sw.ts` file, remember you will also need to add following `workbox` dependencies as `dev`
+> You also need to add the logic to interact from the client logic: [Advanced (injectManifest)](/guide/inject-manifest.html).
+
+Then in your `src/sw.ts` file, remember you will also need to add following `workbox` dependencies as `dev`
 dependencies:
 - `workbox-core`
 - `workbox-routing`


### PR DESCRIPTION
- added large code blocks with `details` + `summary` html blocks: by default collapsed
- add network first strategy to workbox `injectManifest` entry: also include network first race strategy
- fix some wording and rephrase on workbox