### PR TITLE
docs: typo

### DIFF
--- a/docs/frameworks/svelte.md
+++ b/docs/frameworks/svelte.md
@@ -53,7 +53,7 @@ You can use this `ReloadPrompt.svelte` component:
       {/if}
     </div>
     {#if $needRefresh}
-      <button on:click={() => updateServiceWorker(true))}>
+      <button on:click={() => updateServiceWorker(true)}>
         Reload
       </button>
     {/if}
@@ -128,7 +128,7 @@ following code:
 import { useRegisterSW } from 'virtual:pwa-register/svelte';
 
 const updateServiceWorker = useRegisterSW({
-  onRegiterError(error) {}
+  onRegisterError(error) {}
 })
 ```
 


### PR DESCRIPTION
This fixes some typos made in the Svelte doc which, upon copy pasting, would bring errors if not fixed manually.