### PR TITLE
docs: update repo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,61 @@
 <p align='center'>
 <img src='https://repository-images.githubusercontent.com/290129345/d4bfc300-1866-11eb-8602-e672c9dd0e7d' alt="vite-plugin-pwa - Zero-config PWA for Vite">
+Zero-config PWA Framework-agnostic Plugin for Vite
 </p>
 
 <p align='center'>
-<a href='https://www.npmjs.com/package/vite-plugin-pwa'>
-<img src='https://img.shields.io/npm/v/vite-plugin-pwa?color=33A6B8&label='>
+<a href='https://www.npmjs.com/package/vite-plugin-pwa' target="__blank">
+<img src='https://img.shields.io/npm/v/vite-plugin-pwa?color=33A6B8&label=' alt="NPM version">
+</a>
+<a href="https://www.npmjs.com/package/vite-plugin-pwa" target="__blank">
+    <img alt="NPM Downloads" src="https://img.shields.io/npm/dm/vite-plugin-pwa?color=476582&label=">
+</a>
+<a href="https://vite-plugin-pwa.netlify.app/" target="__blank">
+    <img src="https://img.shields.io/static/v1?label=&message=docs%20%26%20guides&color=2e859c" alt="Docs & Guides">
+</a>
+<br>
+<a href="https://github.com/antfu/vite-plugin-pwa" target="__blank">
+<img alt="GitHub stars" src="https://img.shields.io/github/stars/antfu/vite-plugin-pwa?style=social">
 </a>
 </p>
 
 <br>
 
-## Features
+<p align="center">
+  <a href="https://cdn.jsdelivr.net/gh/antfu/static/sponsors.svg">
+    <img src='https://cdn.jsdelivr.net/gh/antfu/static/sponsors.svg'/>
+  </a>
+</p>
 
-- Generate Service Worker with Offline support (via [Workbox](https://developers.google.com/web/tools/workbox))
-- Auto inject Web App [Manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest)
-- Prompt for new content refreshing 
-- Automatic reload when new content available
-- Advanced (injectManifest)  
-- Static assets handling
 
-## Usage
+## 🚀 Features
+
+- 📖 [**Documentation & guides**](https://vite-plugin-pwa.netlify.app/)
+- 👌 **Zero-Config**: sensible built-in default configs for common use cases
+- 🔩 **Extensible**: expose the full ability to customize the behavior of the plugin
+- 🦾 **Type Strong**: written in [Typescript](https://www.typescriptlang.org/)
+- 🔌 **Offline Support**: generate service worker with offline support (via Workbox)
+- ⚡ **Fully tree shakable**: auto inject Web App Manifest
+- 💬 **Prompt for new content**: built-in support for Vanilla JavaScript, Vue 3, React, and Svelte
+- ⚙️ **Stale-while-revalidate**: automatic reload when new content is available
+- ✨ **Static assets handling**: configure static assets for offline support
+
+## 📦 Install
 
 ```bash
 npm i vite-plugin-pwa -D # yarn add vite-plugin-pwa -D
 ```
 
-Add it to `vite.config.js`
+## 🦄 Usage
+
+> 🎩 From version `0.11.0`, `workbox` has been updated to version `6.2.2` (previous versions were using `6.1.5` 
+version): if you are using advanced configuration like `workbox` or `injectManifest` options, you must review the plugin
+configuration, since this new version of `workbox` has breaking changes!!!
+
+Add `VitePWA` plugin to `vite.config.js / vite.config.ts` and configure it:
 
 ```ts
-// vite.config.js
+// vite.config.js / vite.config.ts
 import { VitePWA } from 'vite-plugin-pwa'
 
 export default {
@@ -38,261 +65,17 @@ export default {
 }
 ```
 
-## Configuration
+Read the [📖 documentation](https://vite-plugin-pwa.netlify.app/guide/) for a complete guide on how to configure and use 
+this plugin.
 
-### Simple (generateSW)
-
-```ts
-VitePWA({
-  manifest: {
-    // content of manifest
-  },
-  workbox: {
-    // workbox options for generateSW
-  }
-})
-```
-
-### Prompt for new content 
-
-![](https://user-images.githubusercontent.com/11247099/111190584-330cf880-85f2-11eb-8dad-20ddb84456cf.png)
-
-**Warning**: this is the default option when `strategies` and `registerType` are not configured.
-In order for the service worker to be registered, you must invoke the `registerSW` method
-from the `virtual:pwa-register` module.
-
-```ts
-// main.ts
-import { registerSW } from 'virtual:pwa-register'
-
-const updateSW = registerSW({
-  onNeedRefresh() {
-    // show a prompt to user
-  },
-  onOfflineReady() {
-    // show a ready to work offline to user
-  },
-})
-```
-
-```ts
-// when user clicked the "refresh" button
-updateSW()
-// the page will reload and the up-to-date content will be served.
-```
-
-You can find an example written in Vue 3: [ReloadPrompt.vue](./examples/vue-basic/src/ReloadPrompt.vue).
-
-#### SSR/SSG
-
-If you are using `SSR/SSG`, you need to import `virtual:pwa-register` module using dynamic import and checking if
-`window` is not `undefined`:
-
-```ts
-// pwa.ts
-import { registerSW } from 'virtual:pwa-register'
-registerSW({ /* options */})
-
-// main.ts
-if (typeof window !== 'undefined') {
-    import('./pwa')
-}
-```
-
-### Automatic reload when new content available
-
-**Warning**: in order for the service worker to be registered, you must invoke the` registerSW`
-method from the `virtual:pwa-register` module.
-
-With this option, once the service worker detects new content available, then it will update caches and 
-will reload all browser windows/tabs with the application opened automatically to take the control.
-
-The disadvantage of using this option is that the user can lose data in other browser windows / tabs in which the 
-application is open and is filling in a form.
-
-If your application has forms, it is recommended that you change the behavior to use default `prompt` option to allow
-the user decide when to update the content of the application.
-
-#### Configuration
-
-With this option, the plugin will force `workbox.clientsClaim` and `workbox.skipWaiting` to `true`.
-
-```ts
-VitePWA({
-  registerType: 'autoUpdate',  
-  manifest: {
-    // content of manifest
-  },
-  workbox: {
-    // workbox options for generateSW
-  }
-})
-```
-
-#### Runtime
-
-```ts
-// main.ts
-import { registerSW } from 'virtual:pwa-register'
-
-const updateSW = registerSW({
-  onOfflineReady() {
-    // show a ready to work offline to user
-  },
-})
-```
-
-#### SSR/SSG
-
-If you are using `SSR/SSG`, you need to import `virtual:pwa-register` module using dynamic import and checking if
-`window` is not `undefined`:
-
-```ts
-// pwa.ts
-import { registerSW } from 'virtual:pwa-register'
-registerSW({ /* options */})
-
-// main.ts
-if (typeof window !== 'undefined') {
-    import('./pwa')
-}
-```
-
-### Advanced (injectManifest)
-
-You will need to include `workbox-*` dependencies as `dev dependencies`.
-
-```js
-// sw.js
-import { precacheAndRoute } from 'workbox-precaching'
-// self.__WB_MANIFEST is default injection point
-precacheAndRoute(self.__WB_MANIFEST)
-```
-
-```ts
-// vite.config.js
-VitePWA({
-  strategies: 'injectManifest',
-  manifest: {
-    // content of manifest
-  }
-})
-```
-
-If you need your custom service worker works with `Prompt for new content` behavior, you need to include on it at least
-this code (see also this example: [sw.ts](./examples/vue-basic-inject-manifest/src/sw.ts)):
-```ts
-self.addEventListener('message', (event) => {
-  if (event.data && event.data.type === 'SKIP_WAITING')
-    self.skipWaiting()
-})
-```
-
-You can use Typescript to build your service worker, you can find an example written for a Vue 3 project: 
-[sw.ts](./examples/vue-basic-inject-manifest/src/sw.ts).
-To resolve service worker types, just add `WebWorker` to lib entry on your `tsconfig.json` file, for example:
-```json
-"lib": ["ESNext", "DOM", "WebWorker"],
-```
-
-### Static assets handling
-
-By default, all icons on `PWA Manifest` option found under Vite's `publicDir` option directory, will be included 
-in the service worker *precache*. You can disable this option using `includeManifestIcons: false`.
-
-You can also add another static assets such as `favicon`, `svg` and `font` files using `includeAssets` option.
-The `includeAssets` option will be resolved using `fast-glob` found under Vite's `publicDir` option directory, and so
-you can use regular expressions to include those assets, for example: `includeAssets: ['fonts/*.ttf', 'images/*.png']`.
-You don't need to configure `PWA Manifest icons` on `includeAssets` option.
-
-You can find an example written for a Vue 3 [here](./examples/vue-router/vite.config.ts#L16).
-
-If you need to include other assets that are not under Vite's `publicDir` option directory, you can use the 
-`globPatterns` parameter of [workbox](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.generateSW) 
-or [injectManifest](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.injectManifest)
-plugin options:
-```typescript
-VitePWA({
-  workbox: {
-    globPatterns: [],
-    // ...
-  },
-  // or for injectManifest strategy
-  injectManifest: {
-    globPatterns: [],
-    // ...
-  }  
-})
-```
-
-### Configure application to check for Service Worker updates
-
-As explained in `Manual Updates` entry on `The Service Worker Lifecycle` [here](https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#manual_updates),
-you can use this code to configure this behavior on your application:
-
-```ts
-// main.ts
-import { registerSW } from 'virtual:pwa-register'
-
-const updateSW = registerSW({
-  // other options
-  onRegistered(r) {
-    r && setInterval(() => {
-      r.update()
-    }, 60 * 60 * 1000 /* 1 hour: timeout in milliseconds */)
-  }
-})
-```
-
-**Warning**: since `workbox-window` uses a time-based `heuristic` algorithm to handle service worker updates, if you 
-build your service worker and register it again, if the time between last registration and the new one is less than 
-1 minute, then, `workbox-window` will handle the `service worker update found` event as an external event, and so the
-behavior could be strange (for example, if using `prompt`, instead showing the dialog for new content available, the 
-ready  to work offline dialog will be shown; if using `autoUpdate`, the ready to work offline dialog will be shown and 
-shouldn't be shown).
-
-### Full config
+## 👀 Full config
 
 Check out the type declaration [src/types.ts](./src/types.ts) and the following links for more details.
 
-- [Manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest)
+- [Web app manifests](https://developer.mozilla.org/en-US/docs/Web/Manifest)
 - [Workbox](https://developers.google.com/web/tools/workbox)
 
-### IDE errors 'Cannot find module' (ts2307)
 
-If your TypeScript build step or IDE complain about not being able to find modules or type definitions on imports, add the following to the `compilerOptions.types` array of your `tsconfig.json`:
+## 📄 License
 
-```jsonc
-// tsconfig.json
-{
-  "compilerOptions": {
-    "types": [
-      "vite-plugin-pwa/client"
-    ]
-  }
-}
-```
-
-### Testing service worker
-
-Since this plugin will not generate the service worker on `development`, you can test it on local following these steps:
-
-1) add `serve` script to your `package.json` if not before:
-```json
-"serve": "vite preview"
-```
-2) build your app and run `serve`: `npm run build && npm run serve`.
-
-## Sponsors
-
-This project is part of my <a href='https://github.com/antfu-sponsors'>Sponsor Program</a>
-
-<p align="center">
-  <a href="https://cdn.jsdelivr.net/gh/antfu/static/sponsors.svg">
-    <img src='https://cdn.jsdelivr.net/gh/antfu/static/sponsors.svg'/>
-  </a>
-</p>
-
-## License
-
-MIT License © 2020 [Anthony Fu](https://github.com/antfu)
+MIT License © 2020-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -160,7 +160,7 @@ const slidebars = [
  */
 const config = {
   title: 'Vite Plugin PWA',
-  description: 'Zero-config PWA for Vite',
+  description: 'Zero-config PWA Framework-agnostic Plugin for Vite',
   lang: 'en-US',
   head: [
     ['meta', { name: 'theme-color', content: '#ffffff' }],
@@ -168,8 +168,9 @@ const config = {
     ['link', { rel: 'alternate icon', href: '/favicon.ico', type: 'image/png', sizes: '16x16' }],
     ['link', { rel: 'mask-icon', href: '/safari-pinned-tab.svg', color: '#ffffff' }],
     ['meta', { name: 'author', content: 'Anthony Fu' }],
+    ['meta', { name: 'keywords', content: 'pwa, workbox, vite, vite-plugin' }],
     ['meta', { property: 'og:title', content: 'Vite Plugin PWA' }],
-    ['meta', { property: 'og:description', content: 'Zero-config PWA for Vite' }],
+    ['meta', { property: 'og:description', content: 'Zero-config PWA Framework-agnostic Plugin for Vite' }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
     ['meta', { name: 'twitter:creator', content: '@antfu7' }],
     ['link', { rel: 'apple-touch-icon', href: '/apple-touch-icon.png', sizes: "180x180" }],

--- a/docs/.vitepress/theme/components/HomeFeatures.vue
+++ b/docs/.vitepress/theme/components/HomeFeatures.vue
@@ -110,7 +110,7 @@ const features = computed<Feature[]>(() => {
 
 .feature {
   flex-shrink: 0;
-  padding: 20px 24px;
+  padding: 1rem;
   width: 100%;
 }
 

--- a/docs/.vitepress/theme/components/HomeHero.vue
+++ b/docs/.vitepress/theme/components/HomeHero.vue
@@ -12,7 +12,7 @@ import { isDark } from '../composables/dark'
       </a>
     </p>
 
-    <p class="text-lg">Zero-config PWA for Vite</p>
+    <p class="text-lg">Zero-config PWA Framework-agnostic Plugin for Vite</p>
 
     <!-- <p class="version-img">
       <a href="https://www.npmjs.com/package/vite-plugin-pwa" target="_blank" rel="noopener">

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,18 +5,20 @@ actionText: Get Started
 actionLink: /guide/
 
 features:
-  - title: Zero-Config
+  - title: 👌 Zero-Config
     details: Sensible built-in default configs for common use cases
-  - title: Extensible
+  - title: 🔩 Extensible
     details: Expose the full ability to customize the behavior of the plugin
-  - title: Offline Support
+  - title: 🔌 Offline Support
     details: Generate Service Worker with Offline support (via Workbox)
-  - title: Fully tree shakable
+  - title: ⚡ Fully tree shakable
     details: Auto inject Web App Manifest
-  - title: Prompt for new content
+  - title: 💬 Prompt for new content
     details: Built-in support for Vanilla JavaScript, Vue 3, React, and Svelte
-  - title: Stale-while-revalidate
+  - title: ⚙️ Stale-while-revalidate
     details: Automatic reload when new content is available
+  - title: ✨ Static assets handling
+    details: Configure static assets for offline support
 
 footer: MIT Licensed | Copyright © 2021-PRESENT Anthony Fu
 ---


### PR DESCRIPTION
This PR includes (@antfu review configured icons on `README.md` and `docs/index.md` features icons):
- first version of README.md
  - added hero text plus: npm version, npm month downloads, link to docs and github stars
  - updated features entries with icons
  - deleted all configuration/sample entries
  - added Typescript feature
  - moved sponsors to top
  - updated license including `2020-PRESENT`
  - added warning on new `Usage` entry about `workbox` update: if new version will not be `0.11.0` just update to new one
  - added icon to Features, Install, Usage, Full config and License (heading 2)
- `vitepress` updates:
  - change hero text to include `framework-agnostic plugin`
  - Included icons on features
  - Added `Static Assets Handling` on features
  - Update padding for feature entries (`.feature`) to allow `Prompt for new content` title on 1 line
  - Change `config.js`: updated `description` and `og:description` and added `keyworks` meta head