### PR TITLE
docs: fix seo mobile anchors and nav links for mobile

### DIFF
--- a/docs/.vitepress/theme/components/MdListAnchor.vue
+++ b/docs/.vitepress/theme/components/MdListAnchor.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { useRouter } from 'vitepress'
+
+const props = defineProps<{
+  href: string
+  id?: string
+  external?: boolean
+}>()
+
+const router = useRouter()
+const anchor = ref(null)
+const isExternal = computed(() => props.external === true )
+
+
+const navigate = () => {
+  if (isExternal.value)
+    window.open(props.href, '_blank', 'noreferrer noopener');
+  else
+    router.go(props.href)
+}
+</script>
+
+<template>
+  <li class="li-anchor" :class="[{ 'external': isExternal }]">
+    <div role="link" tabindex="0" class="li-anchor-container" @click="navigate" @keydown.enter="navigate">
+      <span v-if="$slots['heading']" class="heading-text">
+        <slot name="heading"></slot>
+      </span>
+      <span :id="props.id" class="li-anchor-link">
+        <slot name="link"></slot>
+      </span>
+      <span v-if="$slots['trailing']" class="trailing-text">
+        <slot name="trailing"></slot>
+      </span>
+      <OutboundLink v-if="isExternal" />
+    </div>
+    <slot name="nested"></slot>
+  </li>
+</template>
+
+<style scoped>
+.li-anchor {
+  min-height: 48px;
+  vertical-align: middle;
+  line-height: 1.5;
+}
+.li-anchor-container {
+  min-height: 48px;
+  letter-spacing: normal;
+  padding: 4px 0.5rem;
+  position: relative;
+}
+.li-anchor-container:hover {
+  cursor: pointer;
+}
+.li-anchor-link {
+  line-height: 36px;
+  font-size: 1rem;
+  font-weight: bolder;
+  color: var(--c-brand-active);
+  white-space: nowrap;
+  text-decoration: none;
+}
+.li-anchor .li-anchor-container:hover .li-anchor-link {
+  text-decoration: underline;
+}
+
+</style>

--- a/docs/.vitepress/theme/components/NavBar.vue
+++ b/docs/.vitepress/theme/components/NavBar.vue
@@ -58,7 +58,7 @@ defineEmits(['toggle'])
   background-color: var(--c-bg-semi);
 }
 
-@media (min-width: 720px) {
+@media (min-width: 780px) {
   .nav-bar {
     padding: 0.7rem 0.8rem 0.7rem 1.5rem;
   }
@@ -72,7 +72,7 @@ defineEmits(['toggle'])
   display: none;
 }
 
-@media (min-width: 720px) {
+@media (min-width: 780px) {
   .nav {
     display: flex;
   }

--- a/docs/.vitepress/theme/components/NavDropdownLink.vue
+++ b/docs/.vitepress/theme/components/NavDropdownLink.vue
@@ -40,7 +40,7 @@ function toggle() {
   cursor: pointer;
 }
 
-@media (min-width: 720px) {
+@media (min-width: 780px) {
   .nav-dropdown-link {
     height: auto;
     overflow: visible;
@@ -76,7 +76,7 @@ function toggle() {
   outline: 0;
 }
 
-@media (min-width: 720px) {
+@media (min-width: 780px) {
   .button {
     border-bottom: 2px solid transparent;
     padding: 0 4px;
@@ -101,7 +101,7 @@ function toggle() {
   transform: rotate(-90deg);
 }
 
-@media (min-width: 720px) {
+@media (min-width: 780px) {
   .button-arrow.right {
     transform: rotate(0);
   }
@@ -114,7 +114,7 @@ function toggle() {
   @apply md:dark:(border border-gray-400 border-opacity-20);
 }
 
-@media (min-width: 720px) {
+@media (min-width: 780px) {
   .dialog {
     display: none;
     position: absolute;

--- a/docs/.vitepress/theme/components/NavDropdownLink.vue
+++ b/docs/.vitepress/theme/components/NavDropdownLink.vue
@@ -18,8 +18,8 @@ function toggle() {
 </script>
 
 <template>
-  <div class="nav-dropdown-link">
-    <button type="button" class="button" :aria-label="item.ariaLabel" @click="toggle">
+  <div class="nav-dropdown-link" :class="{ open }">
+    <button type="button" class="button" :aria-label="item.ariaLabel" @click="toggle" @keydown.enter="toggle">
       <span class="button-text">{{ item.text }}</span>
       <span class="button-arrow" :class="open ? 'down' : 'right'" />
     </button>

--- a/docs/.vitepress/theme/components/NavDropdownLinkItem.vue
+++ b/docs/.vitepress/theme/components/NavDropdownLinkItem.vue
@@ -32,7 +32,7 @@ const { props: linkProps, isExternal } = useNavLink(propsRefs.item)
   white-space: nowrap;
 }
 
-@media (min-width: 720px) {
+@media (min-width: 780px) {
   .item {
     padding: 0 24px 0 12px;
     line-height: 32px;
@@ -58,7 +58,7 @@ const { props: linkProps, isExternal } = useNavLink(propsRefs.item)
   color: var(--c-text);
 }
 
-@media (min-width: 720px) {
+@media (min-width: 780px) {
   .arrow {
     display: inline-block;
     margin-right: 8px;

--- a/docs/.vitepress/theme/components/NavLink.vue
+++ b/docs/.vitepress/theme/components/NavLink.vue
@@ -41,7 +41,7 @@ const { props: linkProps, isExternal } = useNavLink(propsRefs.item)
   color: var(--c-text);
 }
 
-@media (min-width: 720px) {
+@media (min-width: 780px) {
   .item {
     border-bottom: 2px solid transparent;
     padding: 0;

--- a/docs/.vitepress/theme/components/NavLinks.vue
+++ b/docs/.vitepress/theme/components/NavLinks.vue
@@ -30,7 +30,7 @@ const show = computed(() => links.value)
   border-bottom: 1px solid var(--c-divider);
 }
 
-@media (min-width: 720px) {
+@media (min-width: 780px) {
   .nav-links {
     display: flex;
     padding: 2px 0 0;

--- a/docs/.vitepress/theme/components/Page.vue
+++ b/docs/.vitepress/theme/components/Page.vue
@@ -21,7 +21,7 @@
   padding-top: var(--header-height);
 }
 
-@media (min-width: 720px) {
+@media (min-width: 780px) {
   .page {
     margin-left: var(--sidebar-width);
   }

--- a/docs/.vitepress/theme/components/SideBar.vue
+++ b/docs/.vitepress/theme/components/SideBar.vue
@@ -31,7 +31,7 @@ defineProps({
   transition: transform 0.25s ease;
 }
 
-@media (min-width: 720px) {
+@media (min-width: 780px) {
   .sidebar {
     transform: translateX(0);
   }
@@ -45,7 +45,7 @@ defineProps({
   display: block;
 }
 
-@media (min-width: 720px) {
+@media (min-width: 780px) {
   .nav {
     display: none;
   }

--- a/docs/.vitepress/theme/components/ToggleSideBarButton.vue
+++ b/docs/.vitepress/theme/components/ToggleSideBarButton.vue
@@ -43,7 +43,7 @@ defineEmits(['toggle'])
   height: 1.25rem;
 }
 
-@media screen and (max-width: 719px) {
+@media screen and (max-width: 779px) {
   .sidebar-button {
     display: block;
   }

--- a/docs/.vitepress/theme/styles/layout.css
+++ b/docs/.vitepress/theme/styles/layout.css
@@ -241,7 +241,7 @@ form {
   top: 0;
 }
 
-@media screen and (min-width: 720px) {
+@media screen and (min-width: 780px) {
   .theme.no-sidebar aside {
     display: none;
   }

--- a/docs/.vitepress/theme/styles/sidebar-links.css
+++ b/docs/.vitepress/theme/styles/sidebar-links.css
@@ -24,7 +24,7 @@ a.sidebar-link-item.active {
   padding: .75rem 0 5rem;
 }
 
-@media (min-width: 720px) {
+@media (min-width: 780px) {
   .sidebar > .sidebar-links {
     padding: 1.5rem 0;
   }
@@ -34,7 +34,7 @@ a.sidebar-link-item.active {
   padding-top: .5rem;
 }
 
-@media (min-width: 720px) {
+@media (min-width: 780px) {
   .sidebar > .sidebar-links > .sidebar-link + .sidebar-link {
     padding-top: 1.25rem;
   }

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -12,12 +12,23 @@ you must configure your server to meet PWA requirements, that is, your server mu
 
 ## Servers
 
-- [Netlify](/deployment/netlify)
-- [AWS Amplity](/deployment/aws)
-- [Vercel](/deployment/vercel)
-- [NGINX](/deployment/nginx)
-- [Apache Http Server 2.4+](/deployment/apache)
-
+<ul aria-describedby="servers">
+<md-list-anchor href="/deployment/netlify.html">
+  <template #link>Netlify</template>
+</md-list-anchor>
+<md-list-anchor href="/deployment/aws.html">
+  <template #link>AWS Amplity</template>
+</md-list-anchor>
+<md-list-anchor href="/deployment/vercel.html">
+  <template #link>Vercel</template>
+</md-list-anchor>
+<md-list-anchor href="/deployment/nginx.html">
+  <template #link>NGINX</template>
+</md-list-anchor>
+<md-list-anchor href="/deployment/apache.html">
+  <template #link>Apache Http Server 2.4+</template>
+</md-list-anchor>
+</ul>
 
 ## Testing your application on production
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -88,16 +88,67 @@ the `Service Worker` is serving all assets instead request them to the server.
 ## Available Example Projects
 
 We provide the following example projects:
-- [Vue 3](/examples/vue.html):
-    - [Vue 3 Basic Example](/examples/vue.html#basic): `Ready to work offline` and `Prompt for update`.
-    - [Vue 3 Router Examples](/examples/vue.html#router): set of examples with disparate behaviors.
-    - [Vue 3 injectManifest Example](/examples/vue.html#injectmanifest): `Ready to work offline` and `Prompt for update`.
-- [Svelte](/examples/svelte.html):
-    - [Svelte Basic Example](/examples/svelte.html#basic): `Ready to work offline` and `Prompt for update`.
-    - [Svelte Router Examples](/examples/svelte.html#router): set of examples with disparate behaviors.
-    - [Svelte injectManifest Example](/examples/svelte.html#injectmanifest): `Ready to work offline` and `Prompt for update`.
-- [React](/examples/react.html):
-    - [React Basic Example](/examples/react.html#basic): `Ready to work offline` and `Prompt for update`.
-    - [React Router Examples](/examples/react.html#router): set of examples with disparate behaviors.
-    - [React injectManifest Example](/examples/react.html#injectmanifest): `Ready to work offline` and `Prompt for update`.
-- [VitePress](/examples/vitepress): `Prompt for update`.   
+
+<ul aria-describedby="available-example-projects">
+<md-list-anchor id="vue-examples" href="/examples/vue.html">
+  <template #link>Vue 3</template>
+  <template #nested>
+    <ul aria-describedby="vue-examples">
+      <md-list-anchor href="/examples/vue.html#basic">
+        <template #link>Vue 3 Basic Example</template>
+        <template #trailing>: <code>Ready to work offline</code> and <code>Prompt for update</code>.</template>
+      </md-list-anchor>
+      <md-list-anchor href="/examples/vue.html#router">
+        <template #link>Vue 3 Router Examples</template>
+        <template #trailing>: set of examples with disparate behaviors.</template>
+      </md-list-anchor>
+      <md-list-anchor href="/examples/vue.html#injectmanifest">
+        <template #link>Vue 3 injectManifest Example</template>
+        <template #trailing>: <code>Ready to work offline</code> and <code>Prompt for update</code>.</template>
+      </md-list-anchor>
+    </ul>
+  </template>
+</md-list-anchor>
+<md-list-anchor id="svelte-examples" href="/examples/svelte.html">
+  <template #link>Svelte</template>
+  <template #nested>
+    <ul aria-describedby="svelte-examples">
+      <md-list-anchor href="/examples/svelte.html#basic">
+        <template #link>Svelte Basic Example</template>
+        <template #trailing>: <code>Ready to work offline</code> and <code>Prompt for update</code>.</template>
+      </md-list-anchor>
+      <md-list-anchor href="/examples/svelte.html#router">
+        <template #link>Svelte Router Examples</template>
+        <template #trailing>: set of examples with disparate behaviors.</template>
+      </md-list-anchor>
+      <md-list-anchor href="/examples/svelte.html#injectmanifest">
+        <template #link>Svelte injectManifest Example</template>
+        <template #trailing>: <code>Ready to work offline</code> and <code>Prompt for update</code>.</template>
+      </md-list-anchor>
+    </ul>
+  </template>
+</md-list-anchor>
+<md-list-anchor id="react-examples" href="/examples/react.html">
+  <template #link>React</template>
+  <template #nested>
+    <ul aria-describedby="react-examples">
+      <md-list-anchor href="/examples/react.html#basic">
+        <template #link>React Basic Example</template>
+        <template #trailing>: <code>Ready to work offline</code> and <code>Prompt for update</code>.</template>
+      </md-list-anchor>
+      <md-list-anchor href="/examples/react.html#router">
+        <template #link>React Router Examples</template>
+        <template #trailing>: set of examples with disparate behaviors.</template>
+      </md-list-anchor>
+      <md-list-anchor href="/examples/react.html#injectmanifest">
+        <template #link>React injectManifest Example</template>
+        <template #trailing>: <code>Ready to work offline</code> and <code>Prompt for update</code>.</template>
+      </md-list-anchor>
+    </ul>
+  </template>
+</md-list-anchor>
+<md-list-anchor href="/examples/vitepress.html">
+  <template #link>VitePress</template>
+  <template #trailing>: <code>Prompt for update</code>.</template>
+</md-list-anchor>
+</ul>

--- a/docs/examples/react.md
+++ b/docs/examples/react.md
@@ -91,7 +91,7 @@ pnpm run example:react:router:start:claims:reloadsw
 ## injectManifest
 
 This example project can be found on `examples/react-basic-inject-manifest` package/directory with the following behavior:
-- Custom `Typescript Service Worker`.
+- Custom `TypeScript Service Worker`.
 - Show `Ready to work offlline` on first visit and once the `service worker` ready.
 - Show `Prompt for update` when new `service worker` available.
 

--- a/docs/examples/svelte.md
+++ b/docs/examples/svelte.md
@@ -91,7 +91,7 @@ pnpm run example:svelte:routify:start:claims:reloadsw
 ## injectManifest
 
 This example project can be found on `examples/svelte-basic-inject-manifest` package/directory with the following behavior:
-- Custom `Typescript Service Worker`.
+- Custom `TypeScript Service Worker`.
 - Show `Ready to work offlline` on first visit and once the `service worker` ready.
 - Show `Prompt for update` when new `service worker` available.
 

--- a/docs/examples/vue.md
+++ b/docs/examples/vue.md
@@ -91,7 +91,7 @@ pnpm run example:router:start:claims:reloadsw
 ## injectManifest
 
 This example project can be found on `examples/vue-basic-inject-manifest` package/directory with the following behavior:
-- Custom `Typescript Service Worker`.
+- Custom `TypeScript Service Worker`.
 - Show `Ready to work offlline` on first visit and once the `service worker` ready.
 - Show `Prompt for update` when new `service worker` available.
 

--- a/docs/frameworks/index.md
+++ b/docs/frameworks/index.md
@@ -4,7 +4,7 @@ title: Getting Started | Frameworks
 
 # Getting Started 
 
-This plugin is Framework-agnostic and so you can use it with Vanilla Javascript, Typescript and with any framework.
+This plugin is Framework-agnostic and so you can use it with Vanilla JavaScript, TypeScript and with any framework.
 
 ## Usage
 

--- a/docs/frameworks/index.md
+++ b/docs/frameworks/index.md
@@ -60,7 +60,17 @@ These custom virtual modules will expose a wrapper for `virtual:pwa-register` us
 
 ## Frameworks
 
-- [Vue](/frameworks/vue)
-- [React](/frameworks/react)
-- [Svelte](/frameworks/svelte)
-- [VitePress](/frameworks/vitepress)
+<ul aria-describedby="frameworks">
+<md-list-anchor href="/frameworks/vue.html">
+  <template #link>Vue</template>
+</md-list-anchor>
+<md-list-anchor href="/frameworks/react.html">
+  <template #link>React</template>
+</md-list-anchor>
+<md-list-anchor href="/frameworks/svelte.html">
+  <template #link>Svelte</template>
+</md-list-anchor>
+<md-list-anchor href="/frameworks/vitepress.html">
+  <template #link>VitePress</template>
+</md-list-anchor>
+</ul>

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -42,13 +42,37 @@ export const defineConfig({
 
 ## Features
 
-- [Generate Service Worker](/guide/generate.html) with Offline support
-- Auto inject [Web App manifests](https://developer.mozilla.org/en-US/docs/Web/Manifest) <outbound-link />
-- [Prompt for update](/guide/prompt-for-update.html): prompt for new content refreshing
-- [Automatic reload](/guide/auto-update.html) when new content available
-- [Advanced (injectManifest)](/guide/inject-manifest.html) with Offline support
-- [Static assets handling](/guide/static-assets.html)
-- [Periodic SW updates](/guide/periodic-sw-updates.html)
-- [SW registration errors](/guide/sw-registration-errors.html)
+<ul aria-describedby="features">
+<md-list-anchor href="/guide/generate.html">
+  <template #link>Generate Service Worker</template>
+  <template #trailing>&#160;with Offline support</template>
+</md-list-anchor>
+<md-list-anchor href="https://developer.mozilla.org/en-US/docs/Web/Manifest" external>
+  <template #heading>Auto inject&#160;</template>
+  <template #link>Web App manifests</template>
+  <template #trailing>&#160;</template>
+</md-list-anchor>
+<md-list-anchor href="/guide/prompt-for-update.html">
+  <template #link>Prompt for update</template>
+  <template #trailing>: prompt for new content refreshing</template>
+</md-list-anchor>
+<md-list-anchor href="/guide/auto-update.html">
+  <template #link>Automatic reload</template>
+  <template #trailing>&#160;when new content available</template>
+</md-list-anchor>
+<md-list-anchor href="/guide/auto-update.html">
+  <template #link>Advanced (injectManifest)</template>
+  <template #trailing>&#160;with Offline support</template>
+</md-list-anchor>
+<md-list-anchor href="/guide/static-assets.html">
+  <template #link>Static assets handling</template>
+</md-list-anchor>
+<md-list-anchor href="/guide/periodic-sw-updates.html">
+  <template #link>Periodic SW updates</template>
+</md-list-anchor>
+<md-list-anchor href="/guide/sw-registration-errors.html">
+  <template #link>SW registration errors</template>
+</md-list-anchor>
+</ul>
 
 

--- a/docs/guide/inject-manifest.md
+++ b/docs/guide/inject-manifest.md
@@ -80,9 +80,9 @@ clientsClaim()
 > You also need to add the code to your application described on [Automatic reload](/guide/auto-update.html#runtime)
 
 
-## Typescript support 
+## TypeScript support 
 
-You can use Typescript to write your custom service worker. To resolve service worker types, just add `WebWorker` to `lib` 
+You can use TypeScript to write your custom service worker. To resolve service worker types, just add `WebWorker` to `lib` 
 entry on your `tsconfig.json` file:
 
 ```json

--- a/docs/workbox/index.md
+++ b/docs/workbox/index.md
@@ -17,8 +17,17 @@ This module is for build process purpose (it is a `node` module), that is, `Vite
 service worker.
 
 We focus on 2 methods of this module:
-- [generateWS](/workbox/generate-ws): for generating the service worker.
-- [injectManifest](/workbox/inject-manifest): to build your own service worker.
+
+<ul aria-describedby="workbox-build-module">
+<md-list-anchor href="/workbox/generate-ws.html">
+  <template #link>generateWS</template>
+  <template #trailing>: for generating the service worker.</template>
+</md-list-anchor>
+<md-list-anchor href="/workbox/inject-manifest.html">
+  <template #link>injectManifest</template>
+  <template #trailing>: to build your own service worker.</template>
+</md-list-anchor>
+</ul>
 
 You must read [Which Mode to Use](https://developers.google.com/web/tools/workbox/modules/workbox-build#which_mode_to_use) <outbound-link />
 before decide what strategy to use.


### PR DESCRIPTION
This PR includes:
- changed all markdown lists items using new `MdListAnchor.vue` wrapped with `ul` to increase clickeable area: also resolves seo mobile anchors issues.
- updated all media queries to use 780px instead 720px to avoid nav links overlap with the nav title when changing size
- fix for nav links when included on left menu: right now, entries cannot be expanded with mouse: missing `:class="{ open }"` on `NavDropdownLink.vue`.