### PR TITLE
feat: use vite `build.sourcemap` to configure `workbox sourcemap`

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -101,6 +101,12 @@ export async function resolveOptions(options: Partial<VitePWAOptions>, viteConfi
     workbox.clientsClaim = true
   }
 
+  // use vite build.sourcemap to configure `generateSW` sourcemap
+  if (strategies === 'generateSW' && workbox.sourcemap === undefined) {
+    const sourcemap = viteConfig.build?.sourcemap
+    workbox.sourcemap = sourcemap === true || sourcemap === 'inline' || sourcemap === 'hidden'
+  }
+
   const resolvedVitePWAOptions: ResolvedVitePWAOptions = {
     base: basePath,
     mode,


### PR DESCRIPTION
When using `generateWS` strategy, this PR configures `workbox.sourcemap` with `build.sourcemap` vite option:
- if `workbox.sourcemap` is configured, its value is not changed
- otherwise, if `build.sourcemap` vite option is `true`, `inline` or `hidden` then `workbox.sourcemap` is set to `true` otherwise to `false` 

**NOTE**: the default `build.sourcemap` vite option value is `false`, while the default `workbox.sourcemap` option value is `true`. With this PR, we have aligned both.