### PR TITLE
docs: review 3

### DIFF
--- a/docs/.vitepress/theme/components/CleanupOutdatedCaches.md
+++ b/docs/.vitepress/theme/components/CleanupOutdatedCaches.md
@@ -1,0 +1,5 @@
+The service worker will store all your application assets in a browser cache (or set of caches). Every time you make
+changes to your application and rebuild it, the `service worker` will be also rebuild, including in its cache manifest
+all new modified assets, which will have their revision changed (all assets that have been modified will have a new
+version). Assets that have not been modified will also be included in the service worker manifest cache, but their
+revision will not change from the previous version.

--- a/docs/.vitepress/theme/components/GenerateSWCleanupOutdatedCaches.md
+++ b/docs/.vitepress/theme/components/GenerateSWCleanupOutdatedCaches.md
@@ -1,0 +1,21 @@
+When the user installs the new version of the application, we will have on the service worker cache all new assets and
+also the old ones. To delete old assets (from previous versions that are no longer necessary), you have to configure
+an option on the `workbox` entry of the plugin configuration.
+
+When using the `prompt` strategy, it is not necessary to activate it, the plugin will activate it by default.
+
+We strongly recommend you to **NOT** deactivate the option. If you are curious, you can deactivate it using
+this code on your plugin configuration:
+
+```ts
+import { VitePWA } from 'vite-plugin-pwa'
+export const defineConfig({
+  plugins: [
+    VitePWA({
+      workbox: {
+        cleanupOutdatedCaches: false  
+      }  
+    })
+  ]    
+})
+```

--- a/docs/.vitepress/theme/components/InjectManifestCleanupOutdatedCaches.md
+++ b/docs/.vitepress/theme/components/InjectManifestCleanupOutdatedCaches.md
@@ -1,0 +1,13 @@
+When the user installs the new version of the application, we will have on the service worker cache all new assets and
+also the old ones. To delete old assets (from previous versions that are no longer necessary), and since you are 
+building your own service worker, you will need to add the following code to your custom service worker:
+
+```js
+import { precacheAndRoute, cleanupOutdatedCaches } from 'workbox-precaching'
+
+cleanupOutdatedCaches()
+
+precacheAndRoute(self.__WB_MANIFEST)
+```
+
+We strongly recommend you to include previous code on your custom service worker.

--- a/docs/.vitepress/theme/components/MdListAnchor.vue
+++ b/docs/.vitepress/theme/components/MdListAnchor.vue
@@ -29,10 +29,12 @@ const navigate = () => {
       <span :id="props.id" class="li-anchor-link">
         <slot name="link"></slot>
       </span>
+      <span class="li-anchor-external" v-if="isExternal">
+        <OutboundLink />
+      </span>
       <span v-if="$slots['trailing']" class="trailing-text">
         <slot name="trailing"></slot>
       </span>
-      <OutboundLink v-if="isExternal" />
     </div>
     <slot name="nested"></slot>
   </li>
@@ -64,5 +66,7 @@ const navigate = () => {
 .li-anchor .li-anchor-container:hover .li-anchor-link {
   text-decoration: underline;
 }
-
+.li-anchor-link + .li-anchor-external:before {
+  content: " ";
+}
 </style>

--- a/docs/.vitepress/theme/components/SsrSsg.md
+++ b/docs/.vitepress/theme/components/SsrSsg.md
@@ -1,0 +1,18 @@
+If you are using `SSR/SSG`, you need to import `virtual:pwa-register` module using dynamic import and checking if
+`window` is not `undefined`.
+
+You can register the service worker on `src/pwa.ts` module:
+
+```ts
+import { registerSW } from 'virtual:pwa-register'
+
+registerSW({ ... })
+```
+
+and then import it from your `main.ts`:
+
+```ts
+if (typeof window !== 'undefined') {
+  import('./pwa')
+}
+```

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -109,25 +109,6 @@ We provide the following example projects:
     </ul>
   </template>
 </md-list-anchor>
-<md-list-anchor id="svelte-examples" href="/examples/svelte.html">
-  <template #link>Svelte</template>
-  <template #nested>
-    <ul aria-labelledby="svelte-examples">
-      <md-list-anchor href="/examples/svelte.html#basic">
-        <template #link>Svelte Basic Example</template>
-        <template #trailing>: <code>Ready to work offline</code> and <code>Prompt for update</code>.</template>
-      </md-list-anchor>
-      <md-list-anchor href="/examples/svelte.html#router">
-        <template #link>Svelte Router Examples</template>
-        <template #trailing>: set of examples with disparate behaviors.</template>
-      </md-list-anchor>
-      <md-list-anchor href="/examples/svelte.html#injectmanifest">
-        <template #link>Svelte injectManifest Example</template>
-        <template #trailing>: <code>Ready to work offline</code> and <code>Prompt for update</code>.</template>
-      </md-list-anchor>
-    </ul>
-  </template>
-</md-list-anchor>
 <md-list-anchor id="react-examples" href="/examples/react.html">
   <template #link>React</template>
   <template #nested>
@@ -142,6 +123,25 @@ We provide the following example projects:
       </md-list-anchor>
       <md-list-anchor href="/examples/react.html#injectmanifest">
         <template #link>React injectManifest Example</template>
+        <template #trailing>: <code>Ready to work offline</code> and <code>Prompt for update</code>.</template>
+      </md-list-anchor>
+    </ul>
+  </template>
+</md-list-anchor>
+<md-list-anchor id="svelte-examples" href="/examples/svelte.html">
+  <template #link>Svelte</template>
+  <template #nested>
+    <ul aria-labelledby="svelte-examples">
+      <md-list-anchor href="/examples/svelte.html#basic">
+        <template #link>Svelte Basic Example</template>
+        <template #trailing>: <code>Ready to work offline</code> and <code>Prompt for update</code>.</template>
+      </md-list-anchor>
+      <md-list-anchor href="/examples/svelte.html#router">
+        <template #link>Svelte Router Examples</template>
+        <template #trailing>: set of examples with disparate behaviors.</template>
+      </md-list-anchor>
+      <md-list-anchor href="/examples/svelte.html#injectmanifest">
+        <template #link>Svelte injectManifest Example</template>
         <template #trailing>: <code>Ready to work offline</code> and <code>Prompt for update</code>.</template>
       </md-list-anchor>
     </ul>

--- a/docs/frameworks/index.md
+++ b/docs/frameworks/index.md
@@ -47,8 +47,8 @@ When the user clicks the `OK` button, just hide the prompt shown on `onOfflineRe
 
 ## Custom Vite Virtual Modules
 
-This plugin also exposes a set of virtual modules for [Vue 3](https://v3.vuejs.org/) <outbound-link />, 
-[Svelte](https://svelte.dev/docs) <outbound-link /> and [React](https://reactjs.org/) <outbound-link />.  
+This plugin also exposes a set of virtual modules for [Vue 3](https://v3.vuejs.org/) <outbound-link />,
+[React](https://reactjs.org/) <outbound-link /> and [Svelte](https://svelte.dev/docs) <outbound-link />.  
 
 <p id="virtual-modules-frameworks">These custom virtual modules will expose a wrapper for 
 <code>virtual:pwa-register</code> using framework <code>reactivity system</code>, that is:</p>
@@ -59,15 +59,15 @@ This plugin also exposes a set of virtual modules for [Vue 3](https://v3.vuejs.o
   <template #link>ref</template>
   <template #trailing>&#160;for <code>Vue 3</code>.</template>
 </md-list-anchor>
-<md-list-anchor href="https://svelte.dev/docs#writable" external>
-  <template #heading><code>virtual:pwa-register/svelte</code>:&#160;</template>
-  <template #link>writable</template>
-  <template #trailing>&#160;for <code>Svelte</code>.</template>
-</md-list-anchor>
 <md-list-anchor href="https://reactjs.org/docs/hooks-reference.html#usestate" external>
   <template #heading><code>virtual:pwa-register/react</code>:&#160;</template>
   <template #link>useState</template>
   <template #trailing>&#160;for <code>React</code>.</template>
+</md-list-anchor>
+<md-list-anchor href="https://svelte.dev/docs#writable" external>
+  <template #heading><code>virtual:pwa-register/svelte</code>:&#160;</template>
+  <template #link>writable</template>
+  <template #trailing>&#160;for <code>Svelte</code>.</template>
 </md-list-anchor>
 </ul>
 

--- a/docs/guide/auto-update.md
+++ b/docs/guide/auto-update.md
@@ -30,6 +30,12 @@ VitePWA({
 })
 ```
 
+### Cleanup Outdated Caches
+
+<CleanupOutdatedCaches />
+
+<GenerateSWCleanupOutdatedCaches />
+
 ## Runtime
 
 You must include the following code on your `main.ts` or `main.js` file:
@@ -48,22 +54,5 @@ When the user clicks the `OK` button, just hide the prompt shown on `onOfflineRe
 
 ### SSR/SSG
 
-If you are using `SSR/SSG`, you need to import `virtual:pwa-register` module using dynamic import and checking if
-`window` is not `undefined`.
-
-You can register the service worker on `src/pwa.ts` module:
-
-```ts
-import { registerSW } from 'virtual:pwa-register'
-
-registerSW({ ... })
-```
-
-and then import it from your `main.ts`:
-
-```ts
-if (typeof window !== 'undefined') {
-   import('./pwa')
-}
-```
+<SsrSsg />
 

--- a/docs/guide/inject-manifest.md
+++ b/docs/guide/inject-manifest.md
@@ -32,6 +32,12 @@ import { precacheAndRoute } from 'workbox-precaching'
 precacheAndRoute(self.__WB_MANIFEST)
 ```
 
+### Cleanup Outdated Caches
+
+<CleanupOutdatedCaches />
+
+<InjectManifestCleanupOutdatedCaches />
+
 ## Prompt for new content
 
 If you need your custom service worker works with `Prompt for new content` behavior, you need to change
@@ -53,7 +59,7 @@ self.addEventListener('message', (event) => {
 ## Auto update for new content
 
 If you need your custom service worker works with `Auto update for new content` behavior, you need to change
-your service worker code and the configuration options.
+your service worker code and the plugin configuration options.
 
 ### Setup
 
@@ -114,6 +120,3 @@ declare let self: ServiceWorkerGlobalScope
 
 precacheAndRoute(self.__WB_MANIFEST)
 ```
-
-
-

--- a/docs/guide/prompt-for-update.md
+++ b/docs/guide/prompt-for-update.md
@@ -14,6 +14,12 @@ from the `virtual:pwa-register` module.
 
 Go to [Generate Service Worker](/guide/generate.html) section for basic configuration options.
 
+### Cleanup Outdated Caches
+
+<CleanupOutdatedCaches />
+
+<GenerateSWCleanupOutdatedCaches />
+
 ## Runtime
 
 You must include the following code on your `main.ts` or `main.js` file:
@@ -36,24 +42,8 @@ reload and the up-to-date content will be served.
 In any case, when the user clicks the `Cancel` or `OK` buttons in case `onNeedRefresh` or `onOfflineReady` respectively, 
 close the corresponding showed prompt.
 
+
 ### SSR/SSG
 
-If you are using `SSR/SSG`, you need to import `virtual:pwa-register` module using dynamic import and checking if
-`window` is not `undefined`.
-
-You can register the service worker on `src/pwa.ts` module:
-
-```ts
-import { registerSW } from 'virtual:pwa-register'
-
-registerSW({ ... })
-```
-
-and then import it from your `main.ts`:
-
-```ts
-if (typeof window !== 'undefined') {
-  import('./pwa')
-}
-```
+<SsrSsg />
 


### PR DESCRIPTION
This PR includes:
- add cleanup outdated caches for `generateSW` and `injectManifest` strategies
- add `md` components for `cleanup outdated caches` and for `ssr/ssg`: we reuse them on `md` pages
- modify `MdListAnchor` component to add the external image after the `link slot`
- keep all frameworks ordered, that is, all mentions or lists will be always with this order: `Vue`, `React`, `Svelte` and `VitePress`.

