### PR TITLE
 docs: add generate sw source map 

### DIFF
--- a/docs/.vitepress/theme/components/GenerateSWSourceMap.md
+++ b/docs/.vitepress/theme/components/GenerateSWSourceMap.md
@@ -1,0 +1,21 @@
+Since plugin version `0.11.2`, your service worker's source map will not be generated as it uses the `build.sourcemap` 
+option from the Vite config, which by default is `false`.
+
+Your service worker source map will be generated when Vite's `build.sourcemap` configuration option has the value 
+`true`,  `'online'` or `'hidden'`, and you have not configured the `workbox.sourcemap` option in the plugin 
+configuration.  If you configure the `workbox.sourcemap` option, the plugin will not change that value.
+
+If you want to generate the source map of your service worker, you can use this code:
+
+```ts
+import { VitePWA } from 'vite-plugin-pwa'
+export const defineConfig({
+  plugins: [
+    VitePWA({
+      workbox: {
+        sourcemap: true  
+      }  
+    })
+  ]    
+})
+```

--- a/docs/.vitepress/theme/components/InjectManifestSourceMap.md
+++ b/docs/.vitepress/theme/components/InjectManifestSourceMap.md
@@ -1,0 +1,5 @@
+Since you are building your own service worker, this plugin will use Vite's `build.sourcemap` configuration option,
+which default value is `false`, to generate the source map.
+
+If you want to generate the source map for your service worker, you will need to generate the source map for the 
+entire application.

--- a/docs/guide/auto-update.md
+++ b/docs/guide/auto-update.md
@@ -36,6 +36,10 @@ VitePWA({
 
 <GenerateSWCleanupOutdatedCaches />
 
+### Generate SW Source Map
+
+<GenerateSWSourceMap />
+
 ## Runtime
 
 You must include the following code on your `main.ts` or `main.js` file:

--- a/docs/guide/inject-manifest.md
+++ b/docs/guide/inject-manifest.md
@@ -38,6 +38,10 @@ precacheAndRoute(self.__WB_MANIFEST)
 
 <InjectManifestCleanupOutdatedCaches />
 
+### Generate SW Source Map
+
+<InjectManifestSourceMap />
+
 ## Prompt for new content
 
 If you need your custom service worker works with `Prompt for new content` behavior, you need to change

--- a/docs/guide/prompt-for-update.md
+++ b/docs/guide/prompt-for-update.md
@@ -20,6 +20,10 @@ Go to [Generate Service Worker](/guide/generate.html) section for basic configur
 
 <GenerateSWCleanupOutdatedCaches />
 
+### Generate SW Source Map
+
+<GenerateSWSourceMap />
+
 ## Runtime
 
 You must include the following code on your `main.ts` or `main.js` file:


### PR DESCRIPTION
This PR includes:
- service worker source map for `generateSW` strategy: for `prompt` and `autoUpdate` register types
- service worker source map for `injectManifest` strategy

@antfu For `injectManifest` strategy there is no way to generate the service worker source map only, excluding the app, since the source map is generated from the plugin using rollup using the vite `build.sourcemap` option, maybe we can add an option to generate it but not for the entire app.

