### PR TITLE
docs: include inject manifest assets limit

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -36,9 +36,15 @@ If you find any assets are missing from the service worker's precache manifest, 
 `maximumFileSizeToCacheInBytes`, the default value is **2 MiB**.
 
 You can increase the value to your needs, for example to allow assets up to **3 MiB**:
-
+- when using `generateSW` strategy:
 ```ts
 workbox: {
+  maximumFileSizeToCacheInBytes: 3000000
+}
+```
+- when using `injectManifest` strategy:
+```ts
+injectManifest: {
   maximumFileSizeToCacheInBytes: 3000000
 }
 ```

--- a/src/log.ts
+++ b/src/log.ts
@@ -2,7 +2,7 @@
 import { relative } from 'path'
 import { BuildResult } from 'workbox-build'
 import { ResolvedConfig } from 'vite'
-import { blue, cyan, dim, gray, green, magenta, yellow } from 'chalk'
+import { cyan, dim, green, magenta, yellow } from 'chalk'
 import { version } from '../package.json'
 
 export function logWorkboxResult(strategy: string, buildResult: BuildResult, viteOptions: ResolvedConfig) {


### PR DESCRIPTION
This PR includes:
- split assets size limit for each strategy
- cleanup some unsed `chalk` entries from log module