### PR TITLE
docs(solid-js): promote Show component usage rather than ternary

### DIFF
--- a/docs/frameworks/solidjs.md
+++ b/docs/frameworks/solidjs.md
@@ -41,7 +41,7 @@ You can use this `ReloadPrompt.tsx` component:
 
 ```tsx
 // eslint-disable-next-line no-use-before-define
-import { Component } from "solid-js";
+import { Component, Show } from "solid-js";
 import styles from './ReloadPrompt.module.css'
 
 import { useRegisterSW } from 'virtual:pwa-register/solid'

--- a/docs/frameworks/solidjs.md
+++ b/docs/frameworks/solidjs.md
@@ -68,18 +68,22 @@ const ReloadPrompt: Component = () => {
 
   return (
     <div class={styles.Container}>
-      { (offlineReady() || needRefresh())
-        && <div class={styles.Toast}>
-            <div class={styles.Message}>
-              { offlineReady()
-                ? <span>App ready to work offline</span>
-                : <span>New content available, click on reload button to update.</span>
-              }
-            </div>
-            { needRefresh() && <button class={styles.ToastButton} onClick={() => updateServiceWorker(true)}>Reload</button> }
-            <button class={styles.ToastButton} onClick={() => close()}>Close</button>
+      <Show when={(offlineReady() || needRefresh()}>
+        <div class={styles.Toast}>
+          <div class={styles.Message}>
+            <Show
+              fallback={<span>New content available, click on reload button to update.</span>}
+              when={offlineReady()}
+            >
+              <span>App ready to work offline</span>
+            </Show>
+          </div>
+          <Show when={needRefresh()}>
+            <button class={styles.ToastButton} onClick={() => updateServiceWorker(true)}>Reload</button>
+          </Show>
+          <button class={styles.ToastButton} onClick={() => close()}>Close</button>
         </div>
-      }
+      </Show>
     </div>
   )
 }

--- a/docs/frameworks/solidjs.md
+++ b/docs/frameworks/solidjs.md
@@ -68,7 +68,7 @@ const ReloadPrompt: Component = () => {
 
   return (
     <div class={styles.Container}>
-      <Show when={(offlineReady() || needRefresh()}>
+      <Show when={offlineReady() || needRefresh()}>
         <div class={styles.Toast}>
           <div class={styles.Message}>
             <Show

--- a/examples/solid-router/src/ReloadPrompt.tsx
+++ b/examples/solid-router/src/ReloadPrompt.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/react-in-jsx-scope,react/no-unknown-property */
-import { Component } from 'solid-js'
+import { Component, Show } from 'solid-js'
 import { useRegisterSW } from 'virtual:pwa-register/solid'
 import styles from './ReloadPrompt.module.css'
 
@@ -38,18 +38,22 @@ const ReloadPrompt: Component = () => {
 
   return (
     <div class={styles.Container}>
-      { (offlineReady() || needRefresh())
-          && <div class={styles.Toast}>
-            <div class={styles.Message}>
-              { offlineReady()
-                ? <span>App ready to work offline</span>
-                : <span>New content available, click on reload button to update.</span>
-              }
-            </div>
-            { needRefresh() && <button class={styles.ToastButton} onClick={() => updateServiceWorker(true)}>Reload</button> }
-            <button class={styles.ToastButton} onClick={() => close()}>Close</button>
-          </div>
-      }
+      <Show when={offlineReady() || needRefresh()}>
+        <div class={styles.Toast}>
+         <div class={styles.Message}>
+           <Show
+             fallback={<span>New content available, click on reload button to update.</span>}
+             when={offlineReady()}
+           >
+             <span>App ready to work offline</span> 
+           </Show>
+         </div>
+         <Show when={needRefresh()}>
+           <button class={styles.ToastButton} onClick={() => updateServiceWorker(true)}>Reload</button>
+         </Show>
+         <button class={styles.ToastButton} onClick={() => close()}>Close</button>
+        </div>
+      </Show>
     </div>
   )
 }

--- a/examples/solid-router/src/app.tsx
+++ b/examples/solid-router/src/app.tsx
@@ -6,7 +6,7 @@ import styles from './app.module.css'
 import ReloadPrompt from './ReloadPrompt'
 
 const App: Component = () => {
-  // replaced dyanmicaly
+  // replaced dynamically
   const date = '__DATE__'
 
   const Route = useRoutes(routes)


### PR DESCRIPTION
The SolidJS core team likes to promote the use of `<Show>` component with the fallback attribute as a more expressive way of displaying elements. I made a small revision to this example. Thanks for including SolidJS in the examples, it's quite helpful.

BTW we're using vite-plugin-pwa on solidjs.com =)