### PR TITLE
fix(react): `registerSW` inside `useState`

### DIFF
--- a/src/client/build/react.ts
+++ b/src/client/build/react.ts
@@ -16,18 +16,20 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
   const [needRefresh, setNeedRefresh] = useState(false)
   const [offlineReady, setOfflineReady] = useState(false)
 
-  const updateServiceWorker = registerSW({
-    immediate,
-    onOfflineReady() {
-      setOfflineReady(true)
-      onOfflineReady?.()
-    },
-    onNeedRefresh() {
-      setNeedRefresh(true)
-      onNeedRefresh?.()
-    },
-    onRegistered,
-    onRegisterError,
+  const [updateServiceWorker] = useState(() => {
+    return registerSW({
+      immediate,
+      onOfflineReady() {
+        setOfflineReady(true)
+        onOfflineReady?.()
+      },
+      onNeedRefresh() {
+        setNeedRefresh(true)
+        onNeedRefresh?.()
+      },
+      onRegistered,
+      onRegisterError,
+    })
   })
 
   return {


### PR DESCRIPTION
It seems service worker registration is being called multiple times preventing workbox window to work correctly.

@antfu Don't release yet, I'm fixing also `preact`, from github I don't know how to modify 2 files in the same PR.

closes #171