### PR TITLE
feat: support useCredentials option to enable crossorigin attribute

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -19,6 +19,16 @@ add the following to the `compilerOptions.types` array of your `tsconfig.json`:
 }
 ```
 
+## Web app manifest and 401 status code (Unauthorized)
+
+[Browsers send requests for the web manifest without credentials](https://web.dev/add-manifest/#link-manifest), so if your site sits behind auth, the request will fail with a 401 Unauthorized error – even if the user is logged in.
+
+To send the request with credentials, the `<link rel="manifest">` needs a `crossorigin="use-credentials"` attribute, which you can enable via `useCredentials` in the [plugin options](https://github.com/antfu/vite-plugin-pwa/blob/main/src/types.ts#L79):
+
+```ts
+useCredentials: true;
+```
+
 ## Service Worker Registration Errors
 
 You can handle Service Worker registration errors if you want to notify the user with following code on your `main.ts` 

--- a/src/html.ts
+++ b/src/html.ts
@@ -12,7 +12,8 @@ navigator.serviceWorker.register('${options.base + options.filename}', { scope: 
 }
 
 export function injectServiceWorker(html: string, options: ResolvedVitePWAOptions) {
-  const manifest = options.manifest ? `<link rel="manifest" href="${options.base + FILE_MANIFEST}">` : ''
+  const crossorigin = options.useCredentials ? ' crossorigin="use-credentials"' : ''
+  const manifest = options.manifest ? `<link rel="manifest" href="${options.base + FILE_MANIFEST}"${crossorigin}>` : ''
 
   if (options.injectRegister === 'inline') {
     return html.replace(

--- a/src/options.ts
+++ b/src/options.ts
@@ -50,6 +50,7 @@ export async function resolveOptions(options: Partial<VitePWAOptions>, viteConfi
     base = viteConfig.base,
     includeAssets = undefined,
     includeManifestIcons = true,
+    useCredentials = false,
   } = options
 
   const basePath = resolveBathPath(base)
@@ -122,6 +123,7 @@ export async function resolveOptions(options: Partial<VitePWAOptions>, viteConfi
     strategies,
     workbox,
     manifest,
+    useCredentials,
     injectManifest,
     scope,
     minify,

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,11 @@ export interface VitePWAOptions {
    */
   manifest: Partial<ManifestOptions> | false
   /**
+   * Whether to add the `crossorigin="use-credentials"` attribute to `<link rel="manifest">`
+   * @default false
+   */
+  useCredentials?: boolean
+  /**
    * The workbox object for `generateSW`
    */
   workbox: Partial<GenerateSWOptions>


### PR DESCRIPTION
fix #178 

Verified it works in the vue example as requested in https://github.com/antfu/vite-plugin-pwa/issues/178#issuecomment-982097744.
Not sure if I was supposed to leave the change to the PWA config (`useCredentials: true`) in `examples/vue-router/vite.config.ts` so I didn't commit it for now, but that's a quick change.