### PR TITLE
feat: add `id` to manifest type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -140,7 +140,7 @@ export interface ManifestOptions {
    */
   scope: string
   /**
-   * a string that represents the identity for the application
+   * A string that represents the identity for the application
    */
   id: string
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,10 @@ export interface ManifestOptions {
    */
   scope: string
   /**
+   * a string that represents the identity for the application
+   */
+  id: string
+  /**
    * Defines the default orientation for all the website's top-level
    */
   orientation: 'any' | 'natural' | 'landscape' | 'landscape-primary' | 'landscape-secondary' | 'portrait' | 'portrait-primary' | 'portrait-secondary'


### PR DESCRIPTION
adds `id` to ManifestOptions so that I can set an id without getting a typescript error

https://www.w3.org/TR/appmanifest/#id-member