### PR TITLE
feat: add disable option for sw generation and registration

### DIFF
--- a/docs/scripts/build.ts
+++ b/docs/scripts/build.ts
@@ -6,7 +6,7 @@ const rebuildPwa = async() => {
   const config = await resolveConfig({}, 'build', 'production')
   // when `vite-plugin-pwa` is presented, use it to regenerate SW after rendering
   const pwaPlugin: VitePluginPWAAPI = config.plugins.find(i => i.name === 'vite-plugin-pwa')?.api
-  if (pwaPlugin?.generateSW && !pwaPlugin?.disabled) {
+  if (pwaPlugin && pwaPlugin.generateSW && !pwaPlugin.disabled) {
     await optimizePages()
     await pwaPlugin.generateSW()
   }

--- a/docs/scripts/build.ts
+++ b/docs/scripts/build.ts
@@ -6,7 +6,7 @@ const rebuildPwa = async() => {
   const config = await resolveConfig({}, 'build', 'production')
   // when `vite-plugin-pwa` is presented, use it to regenerate SW after rendering
   const pwaPlugin: VitePluginPWAAPI = config.plugins.find(i => i.name === 'vite-plugin-pwa')?.api
-  if (pwaPlugin?.generateSW && !pwaPlugin.disabled) {
+  if (pwaPlugin?.generateSW && !pwaPlugin?.disabled) {
     await optimizePages()
     await pwaPlugin.generateSW()
   }

--- a/docs/scripts/build.ts
+++ b/docs/scripts/build.ts
@@ -6,7 +6,7 @@ const rebuildPwa = async() => {
   const config = await resolveConfig({}, 'build', 'production')
   // when `vite-plugin-pwa` is presented, use it to regenerate SW after rendering
   const pwaPlugin: VitePluginPWAAPI = config.plugins.find(i => i.name === 'vite-plugin-pwa')?.api
-  if (pwaPlugin?.generateSW) {
+  if (pwaPlugin?.generateSW && !pwaPlugin.disabled) {
     await optimizePages()
     await pwaPlugin.generateSW()
   }

--- a/scripts/run-examples.ts
+++ b/scripts/run-examples.ts
@@ -7,7 +7,7 @@ import {
   blue,
   magenta,
   red,
-  bold,
+  reset,
 } from 'kolorist'
 
 type Color = (str: string | number) => string
@@ -102,7 +102,7 @@ async function init() {
       {
         type: 'select',
         name: 'framework',
-        message: bold(green('Select a framework:')),
+        message: reset('Select a framework:'),
         initial: 0,
         // @ts-ignore
         choices: FRAMEWORKS.map((framework) => {
@@ -116,7 +116,7 @@ async function init() {
       {
         type: 'select',
         name: 'strategy',
-        message: bold(green('Select a strategy:')),
+        message: reset('Select a strategy:'),
         initial: 0,
         // @ts-ignore
         choices: STRATEGIES.map((strategy) => {
@@ -130,7 +130,7 @@ async function init() {
       {
         type: 'select',
         name: 'behavior',
-        message: bold(green('Select a behavior:')),
+        message: reset('Select a behavior:'),
         initial: 0,
         // @ts-ignore
         choices: BEHAVIORS.map((behavior) => {
@@ -144,7 +144,7 @@ async function init() {
       {
         type: 'toggle',
         name: 'reloadSW',
-        message: bold(green('Enable periodic SW updates?')),
+        message: reset('Enable periodic SW updates?'),
         initial: false,
         active: 'yes',
         inactive: 'no',

--- a/scripts/run-examples.ts
+++ b/scripts/run-examples.ts
@@ -7,8 +7,7 @@ import {
   blue,
   magenta,
   red,
-  bgWhite,
-  black,
+  inverse,
 } from 'kolorist'
 
 type Color = (str: string | number) => string
@@ -109,7 +108,7 @@ async function init() {
       {
         type: 'select',
         name: 'framework',
-        message: bgWhite(black('Select a framework:')),
+        message: inverse('Select a framework:'),
         initial: 0,
         choices: FRAMEWORKS.map((framework) => {
           const frameworkColor = framework.color
@@ -126,7 +125,7 @@ async function init() {
       {
         type: 'select',
         name: 'strategy',
-        message: bgWhite(black('Select a strategy:')),
+        message: inverse('Select a strategy:'),
         initial: 0,
         choices: useFramework.strategies.map((strategy) => {
           const strategyColor = strategy.color
@@ -143,7 +142,7 @@ async function init() {
       {
         type: 'select',
         name: 'behavior',
-        message: bgWhite(black('Select a behavior:')),
+        message: inverse('Select a behavior:'),
         initial: 0,
         choices: useStrategy.behaviors.map((behavior) => {
           const behaviorColor = behavior.color
@@ -161,7 +160,7 @@ async function init() {
         {
           type: 'toggle',
           name: 'reloadSW',
-          message: bgWhite(black('Enable periodic SW updates?')),
+          message: inverse('Enable periodic SW updates?'),
           initial: false,
           active: 'yes',
           inactive: 'no',

--- a/scripts/run-examples.ts
+++ b/scripts/run-examples.ts
@@ -7,6 +7,8 @@ import {
   blue,
   magenta,
   red,
+  bgWhite,
+  black,
 } from 'kolorist'
 
 type Color = (str: string | number) => string
@@ -107,7 +109,7 @@ async function init() {
       {
         type: 'select',
         name: 'framework',
-        message: 'Select a framework:',
+        message: bgWhite(black('Select a framework:')),
         initial: 0,
         choices: FRAMEWORKS.map((framework) => {
           const frameworkColor = framework.color
@@ -124,7 +126,7 @@ async function init() {
       {
         type: 'select',
         name: 'strategy',
-        message: 'Select a strategy:',
+        message: bgWhite(black('Select a strategy:')),
         initial: 0,
         choices: useFramework.strategies.map((strategy) => {
           const strategyColor = strategy.color
@@ -141,7 +143,7 @@ async function init() {
       {
         type: 'select',
         name: 'behavior',
-        message: 'Select a behavior:',
+        message: bgWhite(black('Select a behavior:')),
         initial: 0,
         choices: useStrategy.behaviors.map((behavior) => {
           const behaviorColor = behavior.color
@@ -159,7 +161,7 @@ async function init() {
         {
           type: 'toggle',
           name: 'reloadSW',
-          message: 'Enable periodic SW updates?',
+          message: bgWhite(black('Enable periodic SW updates?')),
           initial: false,
           active: 'yes',
           inactive: 'no',

--- a/src/options.ts
+++ b/src/options.ts
@@ -51,6 +51,7 @@ export async function resolveOptions(options: Partial<VitePWAOptions>, viteConfi
     includeAssets = undefined,
     includeManifestIcons = true,
     useCredentials = false,
+    disable = false,
   } = options
 
   const basePath = resolveBathPath(base)
@@ -129,6 +130,7 @@ export async function resolveOptions(options: Partial<VitePWAOptions>, viteConfi
     minify,
     includeAssets,
     includeManifestIcons,
+    disable,
   }
 
   await configureStaticAssets(resolvedVitePWAOptions, viteConfig)

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,8 +103,10 @@ export interface VitePWAOptions {
    * By default the icons listed on `manifest` option will be included
    * on the service worker *precache* if present under Vite's `publicDir`
    * option directory.
+   *
+   * @default true
    */
-  includeManifestIcons: true
+  includeManifestIcons: boolean
 }
 
 export interface ResolvedVitePWAOptions extends Required<VitePWAOptions> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,13 +100,19 @@ export interface VitePWAOptions {
    */
   includeAssets: string | string[] | undefined
   /**
-   * By default the icons listed on `manifest` option will be included
+   * By default, the icons listed on `manifest` option will be included
    * on the service worker *precache* if present under Vite's `publicDir`
    * option directory.
    *
    * @default true
    */
   includeManifestIcons: boolean
+  /**
+   * Disable service worker registration and generation on `build`?
+   *
+   * @default false
+   */
+  disable: boolean
 }
 
 export interface ResolvedVitePWAOptions extends Required<VitePWAOptions> {
@@ -223,6 +229,10 @@ export interface ManifestOptions {
 }
 
 export interface VitePluginPWAAPI {
+  /**
+   * Is the plugin disabled?
+   */
+  disabled: boolean
   extendManifestEntries(fn: ExtendManifestEntriesHook): void
   /*
    * Explicitly generate the manifests.


### PR DESCRIPTION
@antfu also included `disabled` option on `VitePluginPWAAPI` to use it on `vite-ssg`, once approved this PR and released I'll provide another PR there (see last commit). 

This PR also fix the `includeManifestIcons` option on `VitePWAOptions`.

closes #190 