### PR TITLE
docs: fix typos in example configs

### DIFF
--- a/docs/.vitepress/theme/components/GenerateSWCleanupOutdatedCaches.md
+++ b/docs/.vitepress/theme/components/GenerateSWCleanupOutdatedCaches.md
@@ -9,7 +9,7 @@ this code on your plugin configuration:
 
 ```ts
 import { VitePWA } from 'vite-plugin-pwa'
-export const defineConfig({
+export default defineConfig({
   plugins: [
     VitePWA({
       workbox: {

--- a/docs/.vitepress/theme/components/GenerateSWSourceMap.md
+++ b/docs/.vitepress/theme/components/GenerateSWSourceMap.md
@@ -9,7 +9,7 @@ If you want to generate the source map of your service worker, you can use this 
 
 ```ts
 import { VitePWA } from 'vite-plugin-pwa'
-export const defineConfig({
+export default defineConfig({
   plugins: [
     VitePWA({
       workbox: {

--- a/docs/guide/generate.md
+++ b/docs/guide/generate.md
@@ -11,7 +11,7 @@ Edit your `vite.config.ts` file to add `Vite Plugin PWA Plugin`:
 
 ```ts
 import { VitePWA } from 'vite-plugin-pwa'
-export const defineConfig({
+export default defineConfig({
   plugins: [
     VitePWA({
       includeAssets: ['favicon.svg', 'favicon.ico', 'robots.txt', 'apple-touch-icon.png'],  

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -33,7 +33,7 @@ Edit your `vite.config.ts` file to add `Vite Plugin PWA`:
 
 ```ts
 import { VitePWA } from 'vite-plugin-pwa'
-export const defineConfig({
+export default defineConfig({
   plugins: [
     VitePWA({})
   ]    


### PR DESCRIPTION
For some reason there are some typos in example configs