### PR TITLE
docs: fix some erratas on jsdocs and development entry

### DIFF
--- a/docs/guide/development.md
+++ b/docs/guide/development.md
@@ -62,7 +62,7 @@ export type DevOptions = {
    */
   disableRuntimeConfig?: boolean
   /**
-   * This options will allow you to configure the `registerRoute` when using `registerRoute` for `offline` support:,
+   * This option will allow you to configure the `navigateFallback` when using `registerRoute` for `offline` support:,
    * configure here the corresponding `url`, for example `navigateFallback: 'index.html'`.
    *
    * **WARNING**: this option will only be used when using `injectManifest` strategy.   

--- a/src/types.ts
+++ b/src/types.ts
@@ -275,7 +275,7 @@ export type DevOptions = {
    */
   disableRuntimeConfig?: boolean
   /**
-   * This options will allow you to configure the `registerRoute` when using `registerRoute` for `offline` support:,
+   * This option will allow you to configure the `navigateFallback` when using `registerRoute` for `offline` support:,
    * configure here the corresponding `url`, for example `navigateFallback: 'index.html'`.
    *
    * **WARNING**: this option will only be used when using `injectManifest` strategy.


### PR DESCRIPTION
This PR just fix some erratas on jsdocs and development entries, we don't need to release (`src/types.ts` modified only `jsdocs`).