### PR TITLE
feat(inject manifest): add `commonjs` and `vite:json` plugins

### DIFF
--- a/src/modules.ts
+++ b/src/modules.ts
@@ -47,6 +47,7 @@ export async function generateInjectManifest(options: ResolvedVitePWAOptions, vi
     'rollup-plugin-dynamic-import-variables',
     'vite:esbuild-transpile',
     'vite:terser',
+    'commonjs'
   ]
   const plugins = viteOptions.plugins.filter(p => includedPluginNames.includes(p.name)) as Plugin[]
   const bundle = await rollup.rollup({

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -42,6 +42,7 @@ export async function generateInjectManifest(options: ResolvedVitePWAOptions, vi
     'alias',
     'vite:resolve',
     'vite:esbuild',
+    'vite:json',
     'replace',
     'vite:define',
     'rollup-plugin-dynamic-import-variables',

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -43,6 +43,8 @@ export async function generateInjectManifest(options: ResolvedVitePWAOptions, vi
     'vite:resolve',
     'vite:esbuild',
     'vite:json',
+    'vite:worker',
+    'vite:worker-import-meta-url',
     'replace',
     'vite:define',
     'rollup-plugin-dynamic-import-variables',

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -43,8 +43,6 @@ export async function generateInjectManifest(options: ResolvedVitePWAOptions, vi
     'vite:resolve',
     'vite:esbuild',
     'vite:json',
-    'vite:worker',
-    'vite:worker-import-meta-url',
     'replace',
     'vite:define',
     'rollup-plugin-dynamic-import-variables',


### PR DESCRIPTION
Hi, I use a custom service worker with the `'injectManifest'` strategy. When I try to import a commonjs module (e.g. fast-deep-equal), I receive the following error:
```
error during build:
Error: 'default' is not exported by node_modules/fast-deep-equal/index.js, imported by src/sw.ts
    at error (/home/projects/node-9idndn/node_modules/rollup/dist/shared/rollup.js:160:30)
    at Module.error (/home/projects/node-9idndn/node_modules/rollup/dist/shared/rollup.js:12429:16)
    at Module.traceVariable (/home/projects/node-9idndn/node_modules/rollup/dist/shared/rollup.js:12813:29)
    at ModuleScope.findVariable (/home/projects/node-9idndn/node_modules/rollup/dist/shared/rollup.js:11599:39)
    at Identifier.bind (/home/projects/node-9idndn/node_modules/rollup/dist/shared/rollup.js:6479:40)
    at CallExpression.bind (/home/projects/node-9idndn/node_modules/rollup/dist/shared/rollup.js:5087:23)
    at CallExpression.bind (/home/projects/node-9idndn/node_modules/rollup/dist/shared/rollup.js:9436:15)
    at CallExpression.bind (/home/projects/node-9idndn/node_modules/rollup/dist/shared/rollup.js:5083:31)
    at CallExpression.bind (/home/projects/node-9idndn/node_modules/rollup/dist/shared/rollup.js:9436:15)
    at ExpressionStatement.bind (/home/projects/node-9idndn/node_modules/rollup/dist/shared/rollup.js:5087:23)
```
StackBlitz that demonstrates the problem (just run `npm run build`): https://stackblitz.com/edit/node-9idndn?file=src/sw.ts

Vite itself can handle the module by default because it's using the commonjs rollup plugin. I found I can easily make it work in the service worker as well by adding `'commonjs'` to `includedPluginNames` and therefore allowing the PWA plugin to convert the module to esm.

Would you say it's reasonable to include it by default?
Any reason not to and if so how about the possibility to configure it?
