### PR TITLE
docs: Fix spelling and improve wording

### DIFF
--- a/docs/deployment/apache.md
+++ b/docs/deployment/apache.md
@@ -6,7 +6,7 @@ title: Apache Http Server 2.4+ | Deployment
 
 ## Configure `manifest.webmanifest` mime type
 
-You need to configure the following mime type (see basic configuration bellow):
+You need to configure the following mime type (see basic configuration below):
 
 ```ini
 <IfModule mod_mime.c>

--- a/docs/deployment/netlify.md
+++ b/docs/deployment/netlify.md
@@ -6,7 +6,7 @@ title: Netlify | Deployment
 
 ## Configure `manifest.webmanifest` mime type
 
-You need to configure the header entry on `netlify.toml` file (see basic deployment bellow):
+You need to configure the header entry on `netlify.toml` file (see basic deployment below):
 ```toml
 [[headers]]
   for = "/manifest.webmanifest"

--- a/docs/deployment/netlify.md
+++ b/docs/deployment/netlify.md
@@ -6,7 +6,7 @@ title: Netlify | Deployment
 
 ## Configure `manifest.webmanifest` mime type
 
-You need to configure the header entry on `netlify.toml` file (see basic deployment below):
+You need to register the correct MIME type for the web manifest by adding a headers table to your `netlify.toml` file (see basic deployment below):
 ```toml
 [[headers]]
   for = "/manifest.webmanifest"

--- a/docs/deployment/nginx.md
+++ b/docs/deployment/nginx.md
@@ -59,7 +59,7 @@ Double check that **you do not** have caching features enabled, especially `immu
 
 NGINX will add `E-Tag`-headers itself, so there is not much to in that regard.
 
-As a general rule, everything in `/assets/` can have a very long cache time, as everything in there should contain a hash in the filename.
+As a general rule, files in `/assets/` can have a very long cache time, as everything in there should contain a hash in the filename.
 
 An example configuration inside your `server` block could be:
 

--- a/docs/guide/development.md
+++ b/docs/guide/development.md
@@ -6,7 +6,7 @@ title: Development | Guide
 
 From version `v0.11.13` you can use the service worker on development.
 
-The PWA will not be registered, only the service worker logic, check the details for each strategy bellow.
+The PWA will not be registered, only the service worker logic, check the details for each strategy below.
 
 > **Warning**: there will be only one single registration on the service worker precache manifest (`self.__WB_MANIFEST`) 
 when necessary: `navigateFallback`.


### PR DESCRIPTION
### docs: Fix spelling

bellow → below

### docs: Use NGINX’s wording for MIME type in Netlify 

Adapted wording from "Configure `manifest.webmanifest` mime type"
in `nginx.md` because it is more instructive than in `netlify.md`.

### docs: Fix hard-to-read text

"everything in ... as everything"

becomes

"files in ... as everything"