### PR TITLE
docs: Use `netlify.toml` for Cache-Control

### DIFF
--- a/docs/deployment/netlify.md
+++ b/docs/deployment/netlify.md
@@ -14,6 +14,22 @@ You need to configure the header entry on `netlify.toml` file (see basic deploym
     Content-Type = "application/manifest+json"
 ```
 
+## Cache-Control
+
+As a general rule, files in `/assets/` can have a very long cache time, as everything in there should contain a hash in the filename.
+
+Add another headers table to your `netlify.toml` file (see basic deployment below):
+
+```toml
+[[headers]]
+  for = "/assets/*"
+  [headers.values]
+    cache-control = '''
+    max-age=31536000,
+    immutable
+    '''
+```
+
 ## Configure http to https redirection
 
 Netlify will redirect automatically, so you don't worry about it.
@@ -40,12 +56,12 @@ Add `netlify.toml` file to the root directory with the content:
   for = "/manifest.webmanifest"
   [headers.values]
     Content-Type = "application/manifest+json"
-```
 
-Add `_header` file to `public` directory with the content:
-
-```txt
-/assets/*
-  cache-control: max-age=31536000
-  cache-control: immutable
+[[headers]]
+  for = "/assets/*"
+  [headers.values]
+    cache-control = '''
+    max-age=31536000,
+    immutable
+    '''
 ```


### PR DESCRIPTION
instead of `_headers` file.

This method simplifies deployment. One config file is better than two.

This method also allows for more structured configuration & additional
capabilities, as described in the Netlify configuration file syntax.