### PR TITLE
docs: fix default globPatterns

### DIFF
--- a/docs/guide/static-assets.md
+++ b/docs/guide/static-assets.md
@@ -22,7 +22,7 @@ If you configure `globPatterns` on `workbox` or `injectManifest` plugin option, 
 patterns: `globPatterns` will be used by `workbox-build` to match files on `dist` folder.
 <br />
 <br />
-By default, `globPatterns` will be `**.{js,css,html}`: `workbox` will use
+By default, `globPatterns` will be `**/*.{js,css,html}`: `workbox` will use
 [glob primer](https://github.com/isaacs/node-glob#glob-primer) <outbound-link /> to match files using `globPatterns`
 as filter.
 <br />


### PR DESCRIPTION
Ref: https://developer.chrome.com/docs/workbox/reference/workbox-build/#property-GlobPartial-globPatterns

Using `**.{js,css,html}` will not cache any js or css file. It must be `**/*.{js,css,html}`