### PR TITLE
docs: fix generateSW typo

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -146,8 +146,8 @@ const Workbox = [
     link: '/workbox/',
   },
   {
-    text: 'generateWS',
-    link: '/workbox/generate-ws',
+    text: 'generateSW',
+    link: '/workbox/generate-sw',
   },
   {
     text: 'injectManifest',

--- a/docs/guide/static-assets.md
+++ b/docs/guide/static-assets.md
@@ -36,7 +36,7 @@ For example, if you don't include `html` assets pattern, you will get this error
 <br />
 <br />
 
-If you use `generateWS` strategy, then you need to configure `globPatterns` inside `workbox` plugin option:
+If you use `generateSW` strategy, then you need to configure `globPatterns` inside `workbox` plugin option:
 
 ```ts
 VitePWA({

--- a/docs/workbox/generate-sw.md
+++ b/docs/workbox/generate-sw.md
@@ -1,13 +1,13 @@
 ---
-title: generateWS | Workbox
+title: generateSW | Workbox
 ---
 
-# generateWS
+# generateSW
 
 You must read [Which Mode to Use](https://developers.google.com/web/tools/workbox/modules/workbox-build#which_mode_to_use) <outbound-link />
 before decide using this strategy on `vite-plugin-pwa` plugin.
 
-You can find the documentation for this method on `workbox` site: [generateWS](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.generateSW) <outbound-link />.
+You can find the documentation for this method on `workbox` site: [generateSW](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.generateSW) <outbound-link />.
 
 You can find a guide for plugins on `workbox` site: [Using Plugins](https://developers.google.com/web/tools/workbox/guides/using-plugins) <outbound-link />.
 

--- a/docs/workbox/index.md
+++ b/docs/workbox/index.md
@@ -19,8 +19,8 @@ service worker.
 We focus on 2 methods of this module:
 
 <ul aria-labelledby="workbox-build-module">
-<md-list-anchor href="/workbox/generate-ws.html">
-  <template #link>generateWS</template>
+<md-list-anchor href="/workbox/generate-sw.html">
+  <template #link>generateSW</template>
   <template #trailing>: for generating the service worker.</template>
 </md-list-anchor>
 <md-list-anchor href="/workbox/inject-manifest.html">
@@ -32,19 +32,19 @@ We focus on 2 methods of this module:
 You must read [Which Mode to Use](https://developers.google.com/web/tools/workbox/modules/workbox-build#which_mode_to_use) <outbound-link />
 before decide what strategy to use.
 
-`generateWS` method will abstract you from using service worker api when building the service worker. 
-This method can be configured using plugins instead writing your own service worker code (`generateWS` will generate 
+`generateSW` method will abstract you from using service worker api when building the service worker. 
+This method can be configured using plugins instead writing your own service worker code (`generateSW` will generate 
 the code for you).
 
 `injectManifest` method will get your custom service worker and build/compile it.
 
 ## How is `workbox-build` related to `vite-plugin-pwa`?
 
-`vite-plugin-pwa` will use internally `generateWS` and `injectManifest` `workbox` methods when `strategies` 
-option is `generateWS` and `injectManifest` respectively.
+`vite-plugin-pwa` will use internally `generateSW` and `injectManifest` `workbox` methods when `strategies` 
+option is `generateSW` and `injectManifest` respectively.
 
-When you configure `strategies: 'generateWS'` option (it is the default value) on your `vite.config.ts` file, then the 
-plugin invoke the workbox `generateWS` method: the options passed to the `workbox-build` method will be the provided on 
+When you configure `strategies: 'generateSW'` option (it is the default value) on your `vite.config.ts` file, then the 
+plugin invoke the workbox `generateSW` method: the options passed to the `workbox-build` method will be the provided on 
 `workbox` option of the plugin configuration.
 
 When you configure `strategies: 'injectManifest'` plugin option on your `vite.config.ts` file, the plugin will first 

--- a/docs/workbox/inject-manifest.md
+++ b/docs/workbox/inject-manifest.md
@@ -7,7 +7,7 @@ title: injectManifest | Workbox
 You must read [Which Mode to Use](https://developers.google.com/web/tools/workbox/modules/workbox-build#which_mode_to_use) <outbound-link />
 before decide using this strategy on `vite-plugin-pwa` plugin.
 
-Before writing your custom service worker, check if `workbox` can generate the code for you using `generateWS` strategy,
+Before writing your custom service worker, check if `workbox` can generate the code for you using `generateSW` strategy,
 looking for some plugin on `workbox` site on [Runtime Caching Entry](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.RuntimeCachingEntry) <outbound-link />.
 
 You can find the documentation for this method on `workbox` site: [injectManifest](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.injectManifest) <outbound-link />


### PR DESCRIPTION
Some parts of the documentation have `generateWS` which should be `generateSW`