### PR TITLE
feat(injectManifest): allow configure Vite plugins

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,3 +11,15 @@ export const VIRTUAL_MODULES_MAP: Record<string, string> = {
 }
 export const VIRTUAL_MODULES_RESOLVE_PREFIX = '/@vite-plugin-pwa/'
 export const VIRTUAL_MODULES = Object.keys(VIRTUAL_MODULES_MAP)
+export const defaultInjectManifestVitePlugins = [
+  'alias',
+  'commonjs',
+  'vite:resolve',
+  'vite:esbuild',
+  'replace',
+  'vite:define',
+  'rollup-plugin-dynamic-import-variables',
+  'vite:esbuild-transpile',
+  'vite:json',
+  'vite:terser',
+]

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,4 +153,5 @@ export function VitePWA(userOptions: Partial<VitePWAOptions> = {}): Plugin[] {
 
 export * from './types'
 export { cachePreset } from './cache'
+export { defaultInjectManifestVitePlugins } from './constants'
 export type { VitePWAOptions as Options }

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -2,8 +2,7 @@ import { resolve } from 'path'
 import { promises as fs } from 'fs'
 import { BuildResult, injectManifest, generateSW } from 'workbox-build'
 import { ResolvedConfig } from 'vite'
-// eslint-disable-next-line import/default
-import Rollup from 'rollup'
+import { rollup } from 'rollup'
 import type { ResolvedVitePWAOptions } from './types'
 import { logWorkboxResult } from './log'
 import { defaultInjectManifestVitePlugins } from './constants'
@@ -49,9 +48,7 @@ export async function generateInjectManifest(options: ResolvedVitePWAOptions, vi
     includedPluginNames.push(...defaultInjectManifestVitePlugins)
 
   const plugins = viteOptions.plugins.filter(p => includedPluginNames.includes(p.name))
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const rollup = require('rollup') as typeof Rollup
-  const bundle = await rollup.rollup({
+  const bundle = await rollup({
     input: options.swSrc,
     plugins,
   })

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -2,7 +2,6 @@ import { resolve } from 'path'
 import { promises as fs } from 'fs'
 import { BuildResult, injectManifest, generateSW } from 'workbox-build'
 import { ResolvedConfig } from 'vite'
-import { rollup } from 'rollup'
 import type { ResolvedVitePWAOptions } from './types'
 import { logWorkboxResult } from './log'
 import { defaultInjectManifestVitePlugins } from './constants'
@@ -48,6 +47,7 @@ export async function generateInjectManifest(options: ResolvedVitePWAOptions, vi
     includedPluginNames.push(...defaultInjectManifestVitePlugins)
 
   const plugins = viteOptions.plugins.filter(p => includedPluginNames.includes(p.name))
+  const { rollup } = await import('rollup')
   const bundle = await rollup({
     input: options.swSrc,
     plugins,

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -37,17 +37,19 @@ export async function generateInjectManifest(options: ResolvedVitePWAOptions, vi
   // self.__WB_MANIFEST is default injection point
   precacheAndRoute(self.__WB_MANIFEST)
   */
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const rollup = require('rollup') as typeof Rollup
   const vitePlugins = options.vitePlugins
   const includedPluginNames: string[] = []
   if (typeof vitePlugins === 'function')
     includedPluginNames.push(...vitePlugins(viteOptions.plugins.map(p => p.name)))
   else
     includedPluginNames.push(...vitePlugins)
+
   if (includedPluginNames.length === 0)
     includedPluginNames.push(...defaultInjectManifestVitePlugins)
+
   const plugins = viteOptions.plugins.filter(p => includedPluginNames.includes(p.name)) as Plugin[]
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const rollup = require('rollup') as typeof Rollup
   const bundle = await rollup.rollup({
     input: options.swSrc,
     plugins,

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -2,6 +2,7 @@ import { resolve } from 'path'
 import { promises as fs } from 'fs'
 import { BuildResult, injectManifest, generateSW } from 'workbox-build'
 import { ResolvedConfig } from 'vite'
+// eslint-disable-next-line import/default
 import Rollup from 'rollup'
 import type { ResolvedVitePWAOptions } from './types'
 import { logWorkboxResult } from './log'
@@ -47,7 +48,7 @@ export async function generateInjectManifest(options: ResolvedVitePWAOptions, vi
   if (includedPluginNames.length === 0)
     includedPluginNames.push(...defaultInjectManifestVitePlugins)
 
-  const plugins = viteOptions.plugins.filter(p => includedPluginNames.includes(p.name)) as Plugin[]
+  const plugins = viteOptions.plugins.filter(p => includedPluginNames.includes(p.name))
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const rollup = require('rollup') as typeof Rollup
   const bundle = await rollup.rollup({

--- a/src/options.ts
+++ b/src/options.ts
@@ -5,6 +5,7 @@ import { GenerateSWOptions, InjectManifestOptions } from 'workbox-build'
 import { ManifestOptions, VitePWAOptions, ResolvedVitePWAOptions } from './types'
 import { configureStaticAssets } from './assets'
 import { resolveBathPath } from './utils'
+import { defaultInjectManifestVitePlugins } from './constants'
 
 function resolveSwPaths(injectManifest: boolean, root: string, srcDir: string, outDir: string, filename: string): {
   swSrc: string
@@ -99,7 +100,8 @@ export async function resolveOptions(options: Partial<VitePWAOptions>, viteConfi
   const manifest = typeof options.manifest === 'boolean' && !options.manifest
     ? false
     : Object.assign({}, defaultManifest, options.manifest || {})
-  const injectManifest = Object.assign({}, defaultInjectManifest, options.injectManifest || {})
+  const { vitePlugins = defaultInjectManifestVitePlugins, ...userInjectManifest } = options.injectManifest || {}
+  const injectManifest = Object.assign({}, defaultInjectManifest, userInjectManifest)
 
   if ((injectRegister === 'auto' || registerType == null) && registerType === 'autoUpdate') {
     workbox.skipWaiting = true
@@ -143,6 +145,7 @@ export async function resolveOptions(options: Partial<VitePWAOptions>, viteConfi
     includeManifestIcons,
     disable,
     devOptions,
+    vitePlugins,
   }
 
   await configureStaticAssets(resolvedVitePWAOptions, viteConfig)

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,16 @@
 import type { GenerateSWOptions, InjectManifestOptions, ManifestEntry } from 'workbox-build'
 import type { OutputBundle } from 'rollup'
 
+export type InjectManifestVitePlugins = string[] | ((vitePluginIds: string[]) => string[])
+export type CustomInjectManifest = InjectManifestOptions & {
+  /**
+   * `Vite` plugin ids to use on `Rollup` build.
+   *
+   * **WARN**: this option is for advanced usage, beware, you can break the service worker build.
+   */
+  vitePlugins?: InjectManifestVitePlugins
+}
+
 /**
  * Plugin options.
  */
@@ -84,7 +94,7 @@ export interface VitePWAOptions {
   /**
    * The workbox object for `injectManifest`
    */
-  injectManifest: Partial<InjectManifestOptions>
+  injectManifest: Partial<CustomInjectManifest>
   /**
    * Override Vite's base options only for PWA
    *
@@ -124,6 +134,7 @@ export interface ResolvedVitePWAOptions extends Required<VitePWAOptions> {
   swDest: string
   workbox: GenerateSWOptions
   injectManifest: InjectManifestOptions
+  vitePlugins: InjectManifestVitePlugins
 }
 
 export interface ManifestOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import type { GenerateSWOptions, InjectManifestOptions, ManifestEntry } from 'wo
 import type { OutputBundle } from 'rollup'
 
 export type InjectManifestVitePlugins = string[] | ((vitePluginIds: string[]) => string[])
-export type CustomInjectManifest = InjectManifestOptions & {
+export type CustomInjectManifestOptions = InjectManifestOptions & {
   /**
    * `Vite` plugin ids to use on `Rollup` build.
    *
@@ -94,7 +94,7 @@ export interface VitePWAOptions {
   /**
    * The workbox object for `injectManifest`
    */
-  injectManifest: Partial<CustomInjectManifest>
+  injectManifest: Partial<CustomInjectManifestOptions>
   /**
    * Override Vite's base options only for PWA
    *


### PR DESCRIPTION
This PR includes:
- add `commonjs` and `vite:json`
- exports `defaultInjectManifestVitePlugins` from `constants.ts` module
- adds support to configure Vite plugins on `injectManifest` when building using Rollup

supersedes #215 
supersedes #261

closes #260