### PR TITLE
docs: minor improvement to docs/guide/development

### DIFF
--- a/docs/guide/development.md
+++ b/docs/guide/development.md
@@ -84,7 +84,15 @@ Uncaught (in promise) TypeError: Failed to execute 'importScripts' on 'WorkerGlo
 
 ## injectManifest strategy
 
-You can use `type: 'module'` when registering the service worker (right now only supported on latest versions of `Chromium` based browsers: `Chromium/Chrome/Edge`).
+You can use `type: 'module'` when registering the service worker (right now only supported on latest versions of `Chromium` based browsers: `Chromium/Chrome/Edge`):
+
+```ts
+devOptions: {
+  enabled: true,
+  type: 'module',
+  /* other options */  
+}
+```
 
 > **Warning**: when building the application, the PWA Plugin will always register your service worker with `type: 'classic'` for compatibility with all browsers.
 


### PR DESCRIPTION
I was trying to register the sw in dev mode when usng injectmanifest, and it took me a long time to figure out how, because this part of the doc was not plain enough.  Hopefully this change will make it easier.