### PR TITLE
docs: improve the "getting started" section

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -41,7 +41,12 @@ export default defineConfig({
   ]    
 })
 ```
-
+Then register the server worker:
+```ts
+import { registerSW } from "virtual:pwa-register";
+registerSW();
+```
+> note: if you encounter typing issues about `virtual:pwa-register`, check the FAQ [here](https://vite-plugin-pwa.netlify.app/guide/faq.html#ide-errors-cannot-find-module-ts2307).
 ## Features
 
 <ul aria-labelledby="features">


### PR DESCRIPTION
It seems the first chapter of Doc, [Gettings Started](https://vite-plugin-pwa.netlify.app/guide/#getting-started), is meant to tell people "how to add this plugin if you already have a vite project".  However, it only covers adding the plugin and doesn't cover sw registration, so it doesn't really get people _started_.

Note: **I'm not sure if what I added was officially correct. It just worked for me.**