### PR TITLE
Add support for display_override

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -178,6 +178,10 @@ export interface ManifestOptions {
    */
   display: string
   /**
+   * @default []
+   */
+  display_override: string[]
+  /**
    * @default `#ffffff`
    */
   background_color: string


### PR DESCRIPTION
This change adds type support for the [`display_override`](https://developer.mozilla.org/en-US/docs/Web/Manifest/display_override) manifest member.