### PR TITLE
feat: add ESM support

### DIFF
--- a/docs/guide/development.md
+++ b/docs/guide/development.md
@@ -14,6 +14,23 @@ There will be only one single registration on the service worker precache manife
 
 The service worker on development will be only available if `disabled` plugin option is not `true` and the `enable` development option is `true`.
 
+::: warning
+If you're registering the service worker without importing any of the virtual modules, you will need to configure `injectRegister` explicitly in the plugin configuration. There is a race condition we cannot bypass and so, you will need to configure it, `auto` will not work, the plugin will not generate the corresponding `registerSW.js` script:
+```ts
+import { VitePWA } from 'vite-plugin-pwa'
+export default defineConfig({
+  plugins: [
+    VitePWA({ 
+      injectRegister: 'inline', // or injectRegister: 'script'
+      devOptions: {
+        enabled: true
+      }
+    })
+  ]
+})
+```
+:::
+
 ## Plugin configuration
 
 To enable the service worker on development, you only need to add the following options to the plugin configuration:

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -86,13 +86,21 @@ export default defineConfig({
 ```
 :::
 
-If you want to check it in `dev`, add the `devOptions` option to the plugin configuration (you will have the [Web App Manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest) and the generated service worker):
+If you want to check it in `dev`, add the `devOptions` option to the plugin configuration (you will have the [Web App Manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest) and the generated service worker).
+
+::: warning
+In version `0.12.2` the service worker will not be registered in development if not importing one of the virtual modules. There is a bug preventing generating the corresponding script on the entry point.
+
+In version `0.12.3` we have fixed previous bug, but you will need to explicitly configure `injectRegister` with `inline` or `script` and not importing any virtual module: there is a race condition, so we cannot bypass it.
+:::
+
 ```ts
 import { VitePWA } from 'vite-plugin-pwa'
 export default defineConfig({
   plugins: [
     VitePWA({ 
       registerType: 'autoUpdate',
+      injectRegister: 'inline', // or injectRegister: 'script'
       devOptions: {
         enabled: true
       }

--- a/examples/sveltekit-pwa/pwa.js
+++ b/examples/sveltekit-pwa/pwa.js
@@ -36,7 +36,7 @@ const buildPwa = async() => {
 		console.log('Generating PWA...')
 		await pwaPlugin.generateSW()
 		webmanifestDestinations.forEach(d => {
-			copyFileSync('./.svelte-kit/output/client/_app/manifest.webmanifest', `${d}/manifest.webmanifest`)
+			copyFileSync('./.svelte-kit/output/client/_app/immutable/manifest.webmanifest', `${d}/manifest.webmanifest`)
 		})
 		// don't copy workbox, svelte kit will copy it
 		if (pwaConfiguration.strategies === 'injectManifest') {

--- a/package.json
+++ b/package.json
@@ -28,10 +28,17 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./*": "./*"
+  },
   "files": [
     "dist",
-    "index.d.ts",
-    "client.d.ts"
+    "*.d.ts"
   ],
   "scripts": {
     "docs": "npm -C docs run dev",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,3 +22,5 @@ export const defaultInjectManifestVitePlugins = [
   'vite:json',
   'vite:terser',
 ]
+
+export const devSwName = 'dev-sw.js?dev-sw'


### PR DESCRIPTION
This PR also fixes the `injectRegister` on development: we have a race condition, it seem Vite will call the transform on dev before the virtual and so will always generate the `registerSW.js`.

I have added some hints on the docs: if not importing any virtual module and using dev the user MUST explicitly configure `injectRegister` with `inline` or `script`.