### PR TITLE
fix: error when calling `_generateBundle` api

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -18,9 +18,9 @@ export async function _generateSW({ options, viteConfig }: PWAPluginContext) {
     await generateServiceWorker(options, viteConfig)
 }
 
-export function _generateBundle({ options, viteConfig, useImportRegister }: PWAPluginContext, bundle: OutputBundle) {
-  if (options.disable)
-    return
+export function _generateBundle({ options, viteConfig, useImportRegister }: PWAPluginContext, bundle?: OutputBundle) {
+  if (options.disable || !bundle)
+    return undefined
 
   if (options.manifest) {
     bundle[options.manifestFilename] = {
@@ -54,7 +54,7 @@ export function createAPI(ctx: PWAPluginContext): VitePluginPWAAPI {
       return ctx?.options?.disable
     },
     generateBundle(bundle) {
-      return _generateBundle(ctx, bundle!)
+      return _generateBundle(ctx, bundle)
     },
     async generateSW() {
       return await _generateSW(ctx)

--- a/src/api.ts
+++ b/src/api.ts
@@ -20,7 +20,7 @@ export async function _generateSW({ options, viteConfig }: PWAPluginContext) {
 
 export function _generateBundle({ options, viteConfig, useImportRegister }: PWAPluginContext, bundle?: OutputBundle) {
   if (options.disable || !bundle)
-    return undefined
+    return
 
   if (options.manifest) {
     bundle[options.manifestFilename] = {


### PR DESCRIPTION
If calling `generateBundle` api from a script, it will throw an error since there is no check if the bundle is there.