### PR TITLE
feat: use `allowlist` in dev sw

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -91,7 +91,7 @@ If you want to check it in `dev`, add the `devOptions` option to the plugin conf
 import { VitePWA } from 'vite-plugin-pwa'
 export default defineConfig({
   plugins: [
-    VitePWA({ 
+    VitePWA({
       registerType: 'autoUpdate',
       devOptions: {
         enabled: true

--- a/examples/preact-router/src/claims-sw.ts
+++ b/examples/preact-router/src/claims-sw.ts
@@ -10,14 +10,14 @@ precacheAndRoute(self.__WB_MANIFEST)
 // clean old assets
 cleanupOutdatedCaches()
 
-let denylist: undefined | RegExp[]
+let allowlist: undefined | RegExp[]
 if (import.meta.env.DEV)
-  denylist = [/^\/manifest.webmanifest$/]
+  allowlist = [/^\/$/]
 
 // to allow work offline
 registerRoute(new NavigationRoute(
   createHandlerBoundToURL('index.html'),
-  { denylist },
+  { allowlist },
 ))
 
 self.skipWaiting()

--- a/examples/react-router/src/claims-sw.ts
+++ b/examples/react-router/src/claims-sw.ts
@@ -10,14 +10,14 @@ precacheAndRoute(self.__WB_MANIFEST)
 // clean old assets
 cleanupOutdatedCaches()
 
-let denylist: undefined | RegExp[]
+let allowlist: undefined | RegExp[]
 if (import.meta.env.DEV)
-  denylist = [/^\/manifest.webmanifest$/]
+  allowlist = [/^\/$/]
 
 // to allow work offline
 registerRoute(new NavigationRoute(
   createHandlerBoundToURL('index.html'),
-  { denylist },
+  { allowlist },
 ))
 
 self.skipWaiting()

--- a/examples/solid-router/src/claims-sw.ts
+++ b/examples/solid-router/src/claims-sw.ts
@@ -10,14 +10,14 @@ precacheAndRoute(self.__WB_MANIFEST)
 // clean old assets
 cleanupOutdatedCaches()
 
-let denylist: undefined | RegExp[]
+let allowlist: undefined | RegExp[]
 if (import.meta.env.DEV)
-  denylist = [/^\/manifest.webmanifest$/]
+  allowlist = [/^\/$/]
 
 // to allow work offline
 registerRoute(new NavigationRoute(
   createHandlerBoundToURL('index.html'),
-  { denylist },
+  { allowlist },
 ))
 
 self.skipWaiting()

--- a/examples/svelte-routify/src/claims-sw.ts
+++ b/examples/svelte-routify/src/claims-sw.ts
@@ -11,14 +11,14 @@ precacheAndRoute(self.__WB_MANIFEST)
 cleanupOutdatedCaches()
 
 
-let denylist: undefined | RegExp[]
+let allowlist: undefined | RegExp[]
 if (import.meta.env.DEV)
-  denylist = [/^\/manifest.webmanifest$/]
+  allowlist = [/^\/$/]
 
 // to allow work offline
 registerRoute(new NavigationRoute(
   createHandlerBoundToURL('index.html'),
-  { denylist },
+  { allowlist },
 ))
 
 self.skipWaiting()

--- a/examples/sveltekit-pwa/src/claims-sw.ts
+++ b/examples/sveltekit-pwa/src/claims-sw.ts
@@ -11,14 +11,14 @@ precacheAndRoute(self.__WB_MANIFEST)
 cleanupOutdatedCaches()
 
 
-let denylist: undefined | RegExp[]
+let allowlist: undefined | RegExp[]
 if (import.meta.env.DEV)
-  denylist = [/^\/_app\/manifest.webmanifest$/]
+  allowlist = [/^\/$/]
 
 // to allow work offline
 registerRoute(new NavigationRoute(
-  createHandlerBoundToURL('/'),
-  { denylist },
+  createHandlerBoundToURL('index.html'),
+  { allowlist },
 ))
 
 self.skipWaiting()

--- a/examples/vue-router/src/claims-sw.ts
+++ b/examples/vue-router/src/claims-sw.ts
@@ -10,14 +10,14 @@ precacheAndRoute(self.__WB_MANIFEST)
 // clean old assets
 cleanupOutdatedCaches()
 
-let denylist: undefined | RegExp[]
+let allowlist: undefined | RegExp[]
 if (import.meta.env.DEV)
-  denylist = [/^\/manifest.webmanifest$/]
+  allowlist = [/^\/$/]
 
 // to allow work offline
 registerRoute(new NavigationRoute(
   createHandlerBoundToURL('index.html'),
-  { denylist },
+  { allowlist },
 ))
 
 self.skipWaiting()

--- a/src/plugins/dev.ts
+++ b/src/plugins/dev.ts
@@ -115,8 +115,6 @@ export function DevPlugin(ctx: PWAPluginContext): Plugin {
             // the sw precache (self.__SW_MANIFEST) will be empty since we're using `dev-dist` folder
             // we only need to add the navigateFallback if configured
             const navigateFallback = options.workbox.navigateFallback
-            // we need to exclude the manifest.webmanifest from the sw precache: avoid writing it to the dev-dist folder
-            const webManifestUrl = options.devOptions.webManifestUrl ?? `${options.base}${options.manifestFilename}`
             const { filePaths } = await generateServiceWorker(
               Object.assign(
                 {},
@@ -125,7 +123,7 @@ export function DevPlugin(ctx: PWAPluginContext): Plugin {
                   swDest: options.selfDestroying ? swDest : options.swDest,
                   workbox: {
                     ...options.workbox,
-                    navigateFallbackDenylist: [new RegExp(`^${webManifestUrl}$`)],
+                    navigateFallbackAllowlist: options.devOptions.navigateFallbackAllowlist ?? [/^\/$/],
                     runtimeCaching: options.devOptions.disableRuntimeConfig ? undefined : options.workbox.runtimeCaching,
                     // we only include navigateFallback
                     additionalManifestEntries: navigateFallback ? [navigateFallback] : undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -300,7 +300,7 @@ export interface DevOptions {
    */
   disableRuntimeConfig?: boolean
   /**
-   * This option will allow you to configure the `navigateFallback` when using `registerRoute` for `offline` support:,
+   * This option will allow you to configure the `navigateFallback` when using `registerRoute` for `offline` support:
    * configure here the corresponding `url`, for example `navigateFallback: 'index.html'`.
    *
    * **WARNING**: this option will only be used when using `injectManifest` strategy.
@@ -308,11 +308,28 @@ export interface DevOptions {
   navigateFallback?: string
 
   /**
+   * This option will allow you to configure the `navigateFallbackAllowlist`: new option from version `v0.12.4`.
+   *
+   * Since we need at least the entry point in the service worker's precache manifest, we don't want the rest of the assets to be intercepted by the service worker.
+   *
+   * If you configure this option, the plugin will use it instead the default.
+   *
+   * **WARNING**: this option will only be used when using `generateSW` strategy.
+   *
+   * @default [/^\/$/]
+   */
+  navigateFallbackAllowlist?: RegExp[]
+
+  /**
    * On dev mode the `manifest.webmanifest` file can be on other path.
    *
-   * For example, **SvelteKit** will request `/_app/manifest.webmanifest`.
+   * For example, **SvelteKit** will request `/_app/manifest.webmanifest`, when `webmanifest` added to the output bundle, **SvelteKit** will copy it to the `/_app/` folder.
+   *
+   * **WARNING**: this option will only be used when using `generateSW` strategy.
    *
    * @default `${vite.base}${pwaOptions.manifestFilename}`
+   * @deprecated This option has been deprecated from version `v0.12.4`, the plugin will use navigateFallbackAllowlist instead.
+   * @see navigateFallbackAllowlist
    */
   webManifestUrl?: string
 }


### PR DESCRIPTION
This PR will use `allowlist` when creating the sw in development and deprecates the `webManifestUrl`:
- add `webManifestUrl` deprecation
- include the `navigateFallbackAllowlist` with the default
- update the development entry in docs

@antfu when reviewed and merged you can publish a new version `0.12.4`.

closes #346

supersedes #332