### PR TITLE
Fix dev-dist location

### DIFF
--- a/src/plugins/dev.ts
+++ b/src/plugins/dev.ts
@@ -105,7 +105,7 @@ export function DevPlugin(ctx: PWAPluginContext): Plugin {
           return undefined
         }
         if (id.endsWith(swDevOptions.swUrl)) {
-          const globDirectory = resolve(viteConfig.root, viteConfig.outDir, '..',  'dev-dist')
+          const globDirectory = resolve(viteConfig.root, viteConfig.build.outDir, '..',  'dev-dist')
           if (!existsSync(globDirectory))
             mkdirSync(globDirectory)
 
@@ -158,7 +158,7 @@ export function DevPlugin(ctx: PWAPluginContext): Plugin {
 
 async function createDevRegisterSW(options: ResolvedVitePWAOptions, viteConfig: ResolvedConfig) {
   if (options.injectRegister === 'script') {
-    const devDist = resolve(viteConfig.root, viteConfig.outDir, '..', 'dev-dist')
+    const devDist = resolve(viteConfig.root, viteConfig.build.outDir, '..', 'dev-dist')
     if (!existsSync(devDist))
       mkdirSync(devDist)
 

--- a/src/plugins/dev.ts
+++ b/src/plugins/dev.ts
@@ -105,7 +105,7 @@ export function DevPlugin(ctx: PWAPluginContext): Plugin {
           return undefined
         }
         if (id.endsWith(swDevOptions.swUrl)) {
-          const globDirectory = resolve(viteConfig.root, 'dev-dist')
+          const globDirectory = resolve(viteConfig.root, viteConfig.outDir, '..',  'dev-dist')
           if (!existsSync(globDirectory))
             mkdirSync(globDirectory)
 
@@ -158,7 +158,7 @@ export function DevPlugin(ctx: PWAPluginContext): Plugin {
 
 async function createDevRegisterSW(options: ResolvedVitePWAOptions, viteConfig: ResolvedConfig) {
   if (options.injectRegister === 'script') {
-    const devDist = resolve(viteConfig.root, 'dev-dist')
+    const devDist = resolve(viteConfig.root, viteConfig.outDir, '..', 'dev-dist')
     if (!existsSync(devDist))
       mkdirSync(devDist)
 


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The `dev-dist` folder is created relative to the vite `root` setting. Often this is fine but if you want a more typical directory structure by setting `root` to be `src` and `outDir` to be `../dist` then `dev-dist` appears under `src`. not good!

This PR changes the location of `dev-dist` to be a sibling of `outDir`

I tested by hacking `node-modules/vite-plugin-pwa` in https://github.com/music-practice-tools/musical-parameters with my config and the default config.

I think this is a safe change. The only break might be dev-dist moving and so not matching .gitignore

### Linked Issues

None

### Additional context

None