### PR TITLE
fix: respect base path in virtual development SW

### DIFF
--- a/src/plugins/dev.ts
+++ b/src/plugins/dev.ts
@@ -37,7 +37,7 @@ export function DevPlugin(ctx: PWAPluginContext): Plugin {
 
         return html.replace(
           '</body>',
-            `<script type="module" src="${DEV_SW_VIRTUAL}"></script></body>`,
+            `<script type="module" src="${options.base}${DEV_SW_VIRTUAL}"></script></body>`,
         )
       },
     },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

In some cases, projects are behind a reverse proxy even in dev mode. The virtual dev module should respect the `base` option from vite config. 

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
