### PR TITLE
feat: add file_handlers support to webmanifest

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -165,6 +165,10 @@ export interface ManifestOptions {
    */
   icons: Record<string, any>[]
   /**
+   *
+   */
+  file_handlers: Record<string, any>[]
+  /**
    * @default `routerBase + '?standalone=true'`
    */
   start_url: string


### PR DESCRIPTION
This PR adds `file_handlers` option to `ManifestOptions` interface so that Typescript would accept this option if supplied in `VitePWA` function call. Without that the `file_handlers` work, but require workaround such as `// @ts-ignore`.

The Typescript interface is rather simple inspired by `icons` options.

`file_handlers` feature description can be found here https://web.dev/file-handling/.

### Motivation

The purpose of this PR is to avoid `// @ts-ignore` in `vite.config.ts` when defining file handlers.

![](https://user-images.githubusercontent.com/1045362/181094882-35491156-8783-4bcf-a4a4-94de956fffcf.png)