### PR TITLE
fix: escape swType when generating registration file

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -7,7 +7,7 @@ export function generateSimpleSWRegister(options: ResolvedVitePWAOptions, dev: b
   // we are using HMR to load this script: DO NOT ADD window::load event listener
   if (dev) {
     const swType = options.devOptions.type ?? 'classic'
-    return `if('serviceWorker' in navigator) navigator.serviceWorker.register('${path}', { scope: '${options.scope}', type: ${swType} })`
+    return `if('serviceWorker' in navigator) navigator.serviceWorker.register('${path}', { scope: '${options.scope}', type: '${swType}' })`
   }
 
   return `


### PR DESCRIPTION
### Description

The latest version `v0.12.4` added some dev specific logic in the `generateSimpleSWRegister` method to generate the `registerSW.js` file.

The `swType` isn't wrapped in quotation marks, so you see an error, e.g. `Uncaught ReferenceError: classic is not defined`.

This PR just adds the quotation marks.