### PR TITLE
fix(dev): missing `registerSW.js` with `injectManifest` strategy

### DIFF
--- a/src/plugins/dev.ts
+++ b/src/plugins/dev.ts
@@ -108,6 +108,9 @@ registerDevSW();
             return content
           }
 
+          if (swDevOptions.workboxPaths.has(id))
+            return await fs.readFile(swDevOptions.workboxPaths.get(id)!, 'utf-8')
+
           return undefined
         }
         if (id.endsWith(swDevOptions.swUrl)) {

--- a/src/plugins/dev.ts
+++ b/src/plugins/dev.ts
@@ -170,8 +170,13 @@ async function createDevRegisterSW(options: ResolvedVitePWAOptions, viteConfig: 
       mkdirSync(devDist)
 
     const registerSW = resolve(devDist, FILE_SW_REGISTER)
-    if (existsSync(registerSW))
+    if (existsSync(registerSW)) {
+      // since we don't delete the dev-dist folder, we just add it if already exists
+      if (!swDevOptions.workboxPaths.has(registerSW))
+        swDevOptions.workboxPaths.set(normalizePath(`${options.base}${FILE_SW_REGISTER}`), registerSW)
+
       return
+    }
 
     await fs.writeFile(registerSW, generateSimpleSWRegister(options, true), { encoding: 'utf8' })
     swDevOptions.workboxPaths.set(normalizePath(`${options.base}${FILE_SW_REGISTER}`), registerSW)


### PR DESCRIPTION
When using injectManifest strategy with `injectRegister` auto or script, the `registerSW.js` not being served by the dev plugin.

closes #368 